### PR TITLE
remove trailing space from til_classification arg

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -23,7 +23,7 @@ def asc_config(parser):
     parser.add_argument('--task',default='',type=str,required=True,help='what datasets',
                         choices=['asc','dsc','ssc','nli','newsgroup','celeba','femnist','vlcs','cifar10','mnist','fashionmnist','cifar100'])
     parser.add_argument('--scenario',default='',type=str,required=True,help='what senario it will be',
-                        choices=['til_classification ', 'dil_classification']
+                        choices=['til_classification', 'dil_classification']
                         )
     
     parser.add_argument('--output',default='',type=str,required=False,help='(default=%(default)s)')


### PR DESCRIPTION
There's was is a trailing space in til_classification. Otherwise you need to put `til_classification ` in quotes with a trailing space when using command line args, which isn't true for `dil_classification`