### PR TITLE
Add baselines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+scripts/*

--- a/approaches/after_finetune.py
+++ b/approaches/after_finetune.py
@@ -31,12 +31,15 @@ def compute(self,model,train_pool_loader, self_fisher, mask_pre, accelerator):
         self.args.tokenizer.save_pretrained(self.args.output_dir)
         if 'adapter' in self.args.baseline:
             unwrapped_model.model.save_adapter(self.args.output_dir, 'adapter')
-        if 'prompt' in self.args.baseline or 'l2p' in self.args.baseline:
+        if 'l2p' in self.args.baseline:
             torch.save(unwrapped_model.model.keys, os.path.join(self.args.output_dir,  'keys'))
             torch.save(unwrapped_model.model.prompt_pool, os.path.join(self.args.output_dir, 'prompt_pool'))
+        if 'dualprompt' in self.args.baseline:
+            torch.save(unwrapped_model.model.e_prompts, os.path.join(self.args.output_dir, 'e_prompts'))
+            torch.save(unwrapped_model.model.g_prompt, os.path.join(self.args.output_dir, 'g_prompt'))
+            torch.save(unwrapped_model.model.keys, os.path.join(self.args.output_dir, 'keys'))
         if 'adapter_cat' in self.args.baseline:
             torch.save(self.similarity.similarities, os.path.join(self.args.output_dir,  'similarities'))
-
 
     accelerator.wait_for_everyone() # after training
     if 'ewc' in self.args.baseline:

--- a/approaches/after_finetune.py
+++ b/approaches/after_finetune.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 MODEL_CONFIG_CLASSES = list(MODEL_MAPPING.keys())
 MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
 from utils import utils
-from networks.baselines import ewc, hat, cat
+from networks.baselines import ewc, hat, cat, ldbr, derpp, agem
 
 
 
@@ -42,6 +42,11 @@ def compute(self,model,train_pool_loader, self_fisher, mask_pre, accelerator):
     if 'ewc' in self.args.baseline:
         ewc.compute(train_pool_loader, model, self_fisher, accelerator, self.args)
 
+    elif 'ldbr' in self.args.baseline:
+        train_loader_replay = accelerator.prepare(train_pool_loader)
+        ldbr.select_samples_to_store(model.model, self.args.buffer, train_loader_replay, self.args.ft_task)
+        torch.save(self.args.buffer, os.path.join(self.args.output_dir, 'buffer'))
+    
     elif 'adapter_hat' in self.args.baseline   \
             or 'adapter_cat' in self.args.baseline \
             or 'adapter_bcl' in self.args.baseline \
@@ -51,6 +56,17 @@ def compute(self,model,train_pool_loader, self_fisher, mask_pre, accelerator):
         mask = utils.mask(model, accelerator, self.args)
         hat.compute(model, accelerator, mask_pre, mask, self.args)
 
+    elif 'derpp' in self.args.baseline or 'agem' in self.args.baseline:
+        # add data to the buffer
+        train_loader_replay = accelerator.prepare(train_pool_loader)
+        if accelerator.is_main_process:  # only find some to keep, no training
+            derpp.derpp_compute(train_loader_replay, model, self.args.buffer, self.args)
+    
+        if 'agem' in self.args.baseline:
+            torch.save(self.args.grad_dims, os.path.join(self.args.output_dir, 'grad_dims'))
+            torch.save(self.args.grad_xy, os.path.join(self.args.output_dir, 'grad_xy'))
+            torch.save(self.args.grad_er, os.path.join(self.args.output_dir, 'grad_er'))
+    
     return self
         # after training ***********************************************************************************************
 

--- a/approaches/finetune.py
+++ b/approaches/finetune.py
@@ -32,6 +32,7 @@ class Appr(object):
         self.config = config
         self.tanh = torch.nn.Tanh()
         self.sigmoid = torch.nn.Sigmoid()
+        self.mse = torch.nn.MSELoss()
 
         utils.lookfor_baseline_variable(self,args)
 
@@ -245,6 +246,20 @@ class Appr(object):
                                 outputs = model(batch)
 
                             loss = outputs.loss
+
+                            # replay here
+                            if ('ldbr' in self.args.baseline or 'derpp' in self.args.baseline) \
+                                and not (self.args.buffer is None or self.args.buffer.is_empty()) \
+                                and step % self.args.replay_freq == 0:
+                                
+                                replay_batch = self.args.buffer.get_datadict(size=batch['input_ids'].shape[0])
+                                replay_batch['cls_labels'] = replay_batch['labels']
+                                replay_outputs = model(replay_batch)
+                                
+                                loss += replay_outputs.loss * self.args.replay_beta
+                                if 'derpp' in self.args.baseline:
+                                    loss += self.mse(replay_outputs.hidden_states[-1], replay_batch['logits']) * self.args.replay_alpha
+                            
                             # We keep track of the loss at each epoch
                             if self.args.with_tracking:
                                 total_loss += loss.detach().float()
@@ -275,7 +290,28 @@ class Appr(object):
                                         p.grad.data *= utils.get_view_for_tsv(n, model_ori, self.args)  # open for general
                                     # elif 'adapter_cat' in self.args.baseline: #TODO: to open the mask, utils.mask already consder it
                                     #     p.grad.data *= utils.get_similar_mask(self.args.similarity, model, accelerator, self.args)
+                            
+                            if 'agem' in self.args.baseline:
+                                model_ori = accelerator.unwrap_model(model)
+                                from networks.baselines import agem
+                                if not (self.args.buffer is None or self.args.buffer.is_empty()):
+                                    agem.store_grad(model_ori.model.parameters, self.args.grad_xy, self.args.grad_dims)
+                                    model_ori.model.zero_grad()
 
+                                    replay_batch = self.args.buffer.get_datadict(self.args.buffer_size_per_dataset)
+                                    # TODO: consider data loader if needed for efficient
+                                    replay_batch['cls_labels'] = replay_batch['labels']
+                                    outputs = model_ori(replay_batch)
+                                    accelerator.backward(outputs.loss) # also make it cannot deal with task with different #classes, as DREPP
+
+                                    agem.store_grad(model_ori.model.parameters, self.args.grad_er, self.args.grad_dims)
+                                    #
+                                    dot_prod = torch.dot(self.args.grad_xy, self.args.grad_er)
+                                    if dot_prod.item() < 0:
+                                        g_tilde = agem.project(gxy=self.args.grad_xy, ger=self.args.grad_er)
+                                        agem.overwrite_grad(model_ori.model.parameters, g_tilde, self.args.grad_dims)
+                                    else:
+                                        agem.overwrite_grad(model_ori.model.parameters, self.args.grad_xy, self.args.grad_dims)
 
 
                             if 'adapter_hat' in self.args.baseline   \
@@ -363,7 +399,7 @@ class Appr(object):
                 # after training ***********************************************************************************************
 
 
-        self = after_finetune.compute(self,model,train_pool_loader, self_fisher, mask_pre, accelerator)
+        self = after_finetune.compute(self, model, train_pool_loader, self_fisher, mask_pre, accelerator)
 
         accelerator.wait_for_everyone()
         unwrapped_model = accelerator.unwrap_model(model)
@@ -452,6 +488,8 @@ class Appr(object):
                         for out in outp:
                             pred.append(out.max(1)[1])  # out has different size
                         pred = torch.stack(pred).squeeze()
+                    elif 'ldbr' in self.args.baseline:
+                        pred = torch.stack(outp[0]).squeeze().max(1)[1]
                     else:
                         pred = outp.max(1)[1]
 
@@ -501,7 +539,6 @@ class Appr(object):
 
 
                 else: # summerization
-
                     model(batch)
 
                     if 'prompt' in self.args.baseline or 'l2p' in self.args.baseline:

--- a/config.py
+++ b/config.py
@@ -222,7 +222,6 @@ def parse_args():
     parser.add_argument("--base_dir", default='/hdd_3/zke4',type=str, help="task id")
     parser.add_argument("--eval_checkpoint",action="store_true")
     parser.add_argument("--no_repeat_ngram_size", type=int, help="task id")
-
     parser.add_argument(
         "--val_max_target_length",
         type=int,
@@ -324,8 +323,20 @@ def parse_args():
         action="store_true",
         help="Indication whether entity level metrics are to be returner.",
     )
-
-
+    parser.add_argument(
+        '--buffer_size_per_dataset',
+        type=int,
+        default=50,
+        help="buffer size for each dataset",
+    )
+    parser.add_argument(
+        '--replay_freq',
+        type=int,
+        default=10,
+        help='replay frequency. Every 10 step we do replay once.'
+    )
+    parser.add_argument('--replay_beta', default=0.03, type=float, help='(default=%(default)f)')
+    parser.add_argument('--replay_alpha', default=0.01, type=float, help='(default=%(default)f)')
     args = parser.parse_args()
 
     return args

--- a/dataloader/data.py
+++ b/dataloader/data.py
@@ -125,7 +125,7 @@ def get_dataset(accelerator, logger, args):
                     sentence = tmp_data[dt]['sentence']
                     term = tmp_data[dt]['term']
                     cls_labels = label2idx[tmp_data[dt]['polarity']]
-                    datasets[ds]['source'].append(sentence + args.tokenizer.sep_token + term)
+                    datasets[ds]['source'].append(sentence + ' ' + args.tokenizer.sep_token + ' ' + term)
                     datasets[ds]['target'].append(label)
                     datasets[ds]['task'].append(t)
                     datasets[ds]['cls_labels'].append(cls_labels)

--- a/finetune.py
+++ b/finetune.py
@@ -20,9 +20,11 @@ Fine-tuning a 🤗 Transformers model on summarization.
 
 
 #TODO: config + CL + tensorboard
-#TODO: please consider FSDP: https://huggingface.co/docs/accelerate/fsdp
+# TODO: please consider FSDP: https://huggingface.co/docs/accelerate/fsdp
 
 
+from accelerate import Accelerator, DistributedType, DistributedDataParallelKwargs
+from approaches.finetune import Appr
 import argparse
 import json
 import logging
@@ -39,6 +41,7 @@ from datasets import load_dataset, load_metric
 from torch.utils.data import DataLoader
 from tqdm.auto import tqdm
 import datasets
+from datasets import Value
 import transformers
 from accelerate import Accelerator
 # from accelerate.logging import get_logger
@@ -62,10 +65,11 @@ import config
 from utils import utils
 from dataloader.data import get_dataset
 from datasets import Dataset, DatasetDict, concatenate_datasets
-
+from networks.baselines import ldbr
 
 logger = logging.getLogger(__name__)
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/summarization/requirements.txt")
+require_version("datasets>=1.8.0",
+                "To fix: pip install -r examples/pytorch/summarization/requirements.txt")
 
 # You should update this to your particular problem to have better documentation of `model_type`
 MODEL_CONFIG_CLASSES = list(MODEL_MAPPING.keys())
@@ -85,20 +89,15 @@ except (LookupError, OSError):
 args = config.parse_args()
 args = utils.prepare_sequence_finetune(args)
 
-from approaches.finetune import Appr
-from accelerate import Accelerator, DistributedType, DistributedDataParallelKwargs
-
 
 # Initialize the accelerator. We will let the accelerator handle device placement for us in this example.
 # If we're using tracking, we also need to initialize it here and it will by default pick up all supported trackers
 # in the environment
 
 ddp_kwargs = DistributedDataParallelKwargs(find_unused_parameters=True)
-accelerator = Accelerator(mixed_precision=args.mixed_precision,fp16=args.fp16, kwargs_handlers=[ddp_kwargs])
+accelerator = Accelerator(mixed_precision=args.mixed_precision,
+                          fp16=args.fp16, kwargs_handlers=[ddp_kwargs])
 
-# accelerator = (
-#     Accelerator(log_with=args.report_to, logging_dir=args.output_dir) if args.with_tracking else Accelerator()
-# )
 if args.source_prefix is None and args.model_name_or_path in [
     "t5-small",
     "t5-base",
@@ -152,17 +151,21 @@ else:
     logger.warning("You are instantiating a new config instance from scratch.")
 
 if args.tokenizer_name:
-    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_name, use_fast=not args.use_slow_tokenizer)
-elif args.base_model_name_or_path: # for training only
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.tokenizer_name, use_fast=not args.use_slow_tokenizer)
+elif args.base_model_name_or_path:  # for training only
 
     add_space_tokenizer = AutoTokenizer.from_pretrained(args.base_model_name_or_path, use_fast=not args.use_slow_tokenizer,
-                                              add_prefix_space=True)
-    normal_tokenizer = AutoTokenizer.from_pretrained(args.base_model_name_or_path, use_fast=not args.use_slow_tokenizer)
+                                                        add_prefix_space=True)
+    normal_tokenizer = AutoTokenizer.from_pretrained(
+        args.base_model_name_or_path, use_fast=not args.use_slow_tokenizer)
 
     if args.task_name in args.ner_datasets:
-        tokenizer = AutoTokenizer.from_pretrained(args.base_model_name_or_path, use_fast=not args.use_slow_tokenizer, add_prefix_space=True)
+        tokenizer = AutoTokenizer.from_pretrained(
+            args.base_model_name_or_path, use_fast=not args.use_slow_tokenizer, add_prefix_space=True)
     else:
-        tokenizer = AutoTokenizer.from_pretrained(args.base_model_name_or_path, use_fast=not args.use_slow_tokenizer)
+        tokenizer = AutoTokenizer.from_pretrained(
+            args.base_model_name_or_path, use_fast=not args.use_slow_tokenizer)
 
 else:
     raise ValueError(
@@ -175,9 +178,8 @@ args.add_space_tokenizer = add_space_tokenizer
 args.normal_tokenizer = normal_tokenizer
 
 
-datasets,taskcla = get_dataset(accelerator=accelerator, logger=logger, args=args)
-# print('datasets: ',datasets)
-model = utils.lookfor_model_finetune(taskcla,args,config)
+datasets, taskcla = get_dataset(accelerator=accelerator, logger=logger, args=args)
+model = utils.lookfor_model_finetune(taskcla, args, config)
 
 model.model.resize_token_embeddings(len(args.tokenizer))
 if model.teacher is not None:
@@ -186,9 +188,9 @@ if model.teacher is not None:
 args.config = utils.deepcopy(config)
 
 
-
 if 'bart' in args.model_name_or_path and config.decoder_start_token_id is None:
-    raise ValueError("Make sure that `config.decoder_start_token_id` is correctly defined")
+    raise ValueError(
+        "Make sure that `config.decoder_start_token_id` is correctly defined")
 
 logger.info('==> Preparing data..')
 
@@ -201,18 +203,19 @@ if 'mtl' in args.baseline or 'comb' in args.baseline:
             dev_dataset = datasets[t]['dev']
 
         else:
-            train_dataset = concatenate_datasets([train_dataset, datasets[t]['train']])
-            dev_dataset = concatenate_datasets([dev_dataset, datasets[t]['dev']])
+            train_dataset = concatenate_datasets(
+                [train_dataset, datasets[t]['train']])
+            dev_dataset = concatenate_datasets(
+                [dev_dataset, datasets[t]['dev']])
 
 else:
     # TODO: we may want to save some previous data
     train_dataset = datasets[args.ft_task]['train']
     dev_dataset = datasets[args.ft_task]['dev']
 
-##
-
-
-
+if 'ldbr' in args.baseline:
+    train_dataset = ldbr.process_dataset(train_dataset, args.tokenizer)
+    dev_dataset = ldbr.process_dataset(dev_dataset, args.tokenizer)
 
 def preprocess_function(examples):
     # Temporarily set max_target_length for training.
@@ -221,16 +224,18 @@ def preprocess_function(examples):
     inputs = examples[text_column]
     targets = examples[summary_column]
     task_id = examples['task']
-    if 'cls_labels' in examples: cls_labels = examples['cls_labels']
-
+    if 'cls_labels' in examples:
+        cls_labels = examples['cls_labels']
 
     inputs = [prefix + inp for inp in inputs]
 
-    model_inputs = args.tokenizer(inputs, max_length=args.max_source_length, padding=padding, truncation=True)
+    model_inputs = args.tokenizer(
+        inputs, max_length=args.max_source_length, padding=padding, truncation=True)
 
     # Setup the tokenizer for targets
     with args.tokenizer.as_target_tokenizer():
-        labels = args.tokenizer(targets, max_length=args.max_target_length, padding=padding, truncation=True)
+        labels = args.tokenizer(
+            targets, max_length=args.max_target_length, padding=padding, truncation=True)
 
     # If we are padding here, replace all tokenizer.pad_token_id in the labels by -100 when we want to ignore
     # padding in the loss.
@@ -239,10 +244,10 @@ def preprocess_function(examples):
             [(l if l != args.tokenizer.pad_token_id else -100) for l in label] for label in labels["input_ids"]
         ]
 
-
     model_inputs["labels"] = labels["input_ids"]
     model_inputs['task'] = task_id
-    if 'cls_labels' in examples: model_inputs['cls_labels'] = cls_labels
+    if 'cls_labels' in examples:
+        model_inputs['cls_labels'] = cls_labels
 
     return model_inputs
 
@@ -276,13 +281,15 @@ def tokenize_and_align_labels(examples):
                 if ('eval_t' not in locals() and 'eval_t' not in globals()) or args.ft_task == 0 or args.ft_task == eval_t:
                     label_ids.append(label_to_id[label[word_idx]])
                 else:
-                    label_ids.append(label_to_id_dict[args.task_name][label[word_idx]])
+                    label_ids.append(
+                        label_to_id_dict[args.task_name][label[word_idx]])
 
             # For the other tokens in a word, we set the label to either the current label or -100, depending on
             # the label_all_tokens flag.
             else:
                 if args.label_all_tokens:
-                    label_ids.append(b_to_i_label[label_to_id[label[word_idx]]])
+                    label_ids.append(
+                        b_to_i_label[label_to_id[label[word_idx]]])
                 else:
                     label_ids.append(-100)
             previous_word_idx = word_idx
@@ -290,7 +297,6 @@ def tokenize_and_align_labels(examples):
         labels.append(label_ids)
     tokenized_inputs["cls_labels"] = labels
     tokenized_inputs["labels"] = labels
-
 
     task_id = examples['task']
 
@@ -309,74 +315,66 @@ prefix = args.source_prefix if args.source_prefix is not None else ""
 
 text_column = 'source'
 summary_column = 'target'
-column_names = [text_column,summary_column]
-
-
-
+column_names = [text_column, summary_column]
 
 
 label_list_dict = \
-{
-    'conll2003': ['O', 'B-PER', 'I-PER', 'B-ORG', 'I-ORG', 'B-LOC', 'I-LOC', 'B-MISC', 'I-MISC'],
-    'wnut2017': ['O', 'B-location', 'I-location', 'B-corporation', 'I-corporation', 'B-person', 'I-person',
-                    'B-product', 'I-product', 'B-creative-work', 'I-creative-work',
-                    'B-group', 'I-group'],
-    'wikigold': ['O', 'B-PER', 'I-PER', 'B-ORG', 'I-ORG', 'B-LOC', 'I-LOC', 'B-MISC', 'I-MISC'],
-    'ontonote': ['O', 'B-PERSON', 'I-PERSON', 'B-NORP', 'I-NORP', 'B-FAC', 'I-FAC',
-                        'B-ORG', 'I-ORG', 'B-GPE', 'I-GPE',
-                        'B-LOC', 'I-LOC', 'B-PRODUCT', 'I-PRODUCT',
-                        'B-EVENT', 'I-EVENT','B-WORK_OF_ART','I-WORK_OF_ART',
-                        'B-LAW', 'I-LAW', 'B-LANGUAGE', 'I-LANGUAGE',
-                        'B-DATE', 'I-DATE', 'B-TIME', 'I-TIME',
-                        'B-PERCENT', 'I-PERCENT', 'B-MONEY', 'I-MONEY',
-                        'B-QUANTITY', 'I-QUANTITY', 'B-ORDINAL', 'I-ORDINAL',
-                        'B-CARDINAL', 'I-CARDINAL'
-                        ],
-    'btc': ['O', 'B-PER', 'I-PER', 'B-ORG', 'I-ORG', 'B-LOC', 'I-LOC', 'B-MISC', 'I-MISC'],
-    'ieer': ['O', 'B-PER', 'I-PER', 'B-LOC', 'I-LOC', 'B-ORG', 'I-ORG',
-                        'B-PCT', 'I-PCT', 'B-MON', 'I-MON',
-                        'B-TIM', 'I-TIM', 'B-DAT', 'I-DAT',
-                        'B-DUR', 'I-DUR','B-CAR','I-CAR',
-                        'B-MEA', 'I-MEA'
-                        ],
-    'ritter': ['O', 'B-person', 'I-person', 'B-geo-loc', 'I-geo-loc', 'B-facility', 'I-facility',
-                    'B-company', 'I-company', 'B-sportsteam', 'I-sportsteam',
-                    'B-musicartist', 'I-musicartist', 'B-product', 'I-product',
-                    'B-tvshow', 'I-tvshow','B-movie','I-movie',
-                    'B-other', 'I-other'
-                    ],
-    're3d': ['O', 'B-Person', 'I-Person', 'B-DocumentReference', 'I-DocumentReference', 'B-Location', 'I-Location',
-                        'B-MilitaryPlatform', 'I-MilitaryPlatform', 'B-Money', 'I-Money',
-                        'B-Nationality', 'I-Nationality', 'B-Organisation', 'I-Organisation',
-                        'B-Quantity', 'I-Quantity','B-Temporal','I-Temporal',
-                        'B-Weapon', 'I-Weapon'
-                        ],
-    'gum': ['O', 'B-person', 'I-person', 'B-place', 'I-place', 'B-organization', 'I-organization',
-                        'B-quantity', 'I-quantity', 'B-time', 'I-time',
-                        'B-event', 'I-event', 'B-abstract', 'I-abstract',
-                        'B-substance', 'I-substance','B-object','I-object',
-                        'B-animal', 'I-animal','B-plant', 'I-plant'
-                        ]
-}
-
+    {
+        'conll2003': ['O', 'B-PER', 'I-PER', 'B-ORG', 'I-ORG', 'B-LOC', 'I-LOC', 'B-MISC', 'I-MISC'],
+        'wnut2017': ['O', 'B-location', 'I-location', 'B-corporation', 'I-corporation', 'B-person', 'I-person',
+                     'B-product', 'I-product', 'B-creative-work', 'I-creative-work',
+                     'B-group', 'I-group'],
+        'wikigold': ['O', 'B-PER', 'I-PER', 'B-ORG', 'I-ORG', 'B-LOC', 'I-LOC', 'B-MISC', 'I-MISC'],
+        'ontonote': ['O', 'B-PERSON', 'I-PERSON', 'B-NORP', 'I-NORP', 'B-FAC', 'I-FAC',
+                     'B-ORG', 'I-ORG', 'B-GPE', 'I-GPE',
+                     'B-LOC', 'I-LOC', 'B-PRODUCT', 'I-PRODUCT',
+                     'B-EVENT', 'I-EVENT', 'B-WORK_OF_ART', 'I-WORK_OF_ART',
+                     'B-LAW', 'I-LAW', 'B-LANGUAGE', 'I-LANGUAGE',
+                     'B-DATE', 'I-DATE', 'B-TIME', 'I-TIME',
+                     'B-PERCENT', 'I-PERCENT', 'B-MONEY', 'I-MONEY',
+                     'B-QUANTITY', 'I-QUANTITY', 'B-ORDINAL', 'I-ORDINAL',
+                     'B-CARDINAL', 'I-CARDINAL'
+                     ],
+        'btc': ['O', 'B-PER', 'I-PER', 'B-ORG', 'I-ORG', 'B-LOC', 'I-LOC', 'B-MISC', 'I-MISC'],
+        'ieer': ['O', 'B-PER', 'I-PER', 'B-LOC', 'I-LOC', 'B-ORG', 'I-ORG',
+                 'B-PCT', 'I-PCT', 'B-MON', 'I-MON',
+                 'B-TIM', 'I-TIM', 'B-DAT', 'I-DAT',
+                 'B-DUR', 'I-DUR', 'B-CAR', 'I-CAR',
+                 'B-MEA', 'I-MEA'
+                 ],
+        'ritter': ['O', 'B-person', 'I-person', 'B-geo-loc', 'I-geo-loc', 'B-facility', 'I-facility',
+                   'B-company', 'I-company', 'B-sportsteam', 'I-sportsteam',
+                   'B-musicartist', 'I-musicartist', 'B-product', 'I-product',
+                   'B-tvshow', 'I-tvshow', 'B-movie', 'I-movie',
+                   'B-other', 'I-other'
+                   ],
+        're3d': ['O', 'B-Person', 'I-Person', 'B-DocumentReference', 'I-DocumentReference', 'B-Location', 'I-Location',
+                 'B-MilitaryPlatform', 'I-MilitaryPlatform', 'B-Money', 'I-Money',
+                 'B-Nationality', 'I-Nationality', 'B-Organisation', 'I-Organisation',
+                 'B-Quantity', 'I-Quantity', 'B-Temporal', 'I-Temporal',
+                 'B-Weapon', 'I-Weapon'
+                 ],
+        'gum': ['O', 'B-person', 'I-person', 'B-place', 'I-place', 'B-organization', 'I-organization',
+                'B-quantity', 'I-quantity', 'B-time', 'I-time',
+                'B-event', 'I-event', 'B-abstract', 'I-abstract',
+                'B-substance', 'I-substance', 'B-object', 'I-object',
+                'B-animal', 'I-animal', 'B-plant', 'I-plant'
+                ]
+    }
 
 
 label_to_id_dict = \
-{
-    'conll2003': {l: i for i, l in enumerate(label_list_dict['conll2003'])},
-    'wnut2017': {l: i for i, l in enumerate(label_list_dict['wnut2017'])},
-    'wikigold': {l: i for i, l in enumerate(label_list_dict['wikigold'])},
-    'ontonote': {l: i for i, l in enumerate(label_list_dict['ontonote'])},
-    'btc': {l: i for i, l in enumerate(label_list_dict['btc'])},
-    'ieer': {l: i for i, l in enumerate(label_list_dict['ieer'])},
-    'ritter': {l: i for i, l in enumerate(label_list_dict['ritter'])},
-    're3d': {l: i for i, l in enumerate(label_list_dict['re3d'])},
-    'gum': {l: i for i, l in enumerate(label_list_dict['gum'])},
-}
-
-
-
-
+    {
+        'conll2003': {l: i for i, l in enumerate(label_list_dict['conll2003'])},
+        'wnut2017': {l: i for i, l in enumerate(label_list_dict['wnut2017'])},
+        'wikigold': {l: i for i, l in enumerate(label_list_dict['wikigold'])},
+        'ontonote': {l: i for i, l in enumerate(label_list_dict['ontonote'])},
+        'btc': {l: i for i, l in enumerate(label_list_dict['btc'])},
+        'ieer': {l: i for i, l in enumerate(label_list_dict['ieer'])},
+        'ritter': {l: i for i, l in enumerate(label_list_dict['ritter'])},
+        're3d': {l: i for i, l in enumerate(label_list_dict['re3d'])},
+        'gum': {l: i for i, l in enumerate(label_list_dict['gum'])},
+    }
 
 
 # ======================================================================
@@ -384,6 +382,8 @@ ner_features = train_dataset.features
 
 # In the event the labels are not a `Sequence[ClassLabel]`, we will need to go through the dataset to get the
 # unique labels.
+
+
 def get_label_list(labels):
     unique_labels = set()
     for label in labels:
@@ -392,7 +392,8 @@ def get_label_list(labels):
     label_list.sort()
     return label_list
 
-if args.task_name in args.ner_datasets: #place holder
+
+if args.task_name in args.ner_datasets:  # place holder
     # If the labels are of type ClassLabel, they are already integers and we have the map stored somewhere.
     # Otherwise, we have to get the list of labels manually.}
     # label_list = get_label_list(train_dataset[summary_column])
@@ -403,7 +404,6 @@ if args.task_name in args.ner_datasets: #place holder
 
     print('label_list: ', label_list)
     print('label_to_id: ', label_to_id)
-
 
     # Model has labels -> use them.
     if model.config.label2id != PretrainedConfig(num_labels=num_labels).label2id:
@@ -420,7 +420,8 @@ if args.task_name in args.ner_datasets: #place holder
 
     # Set the correspondences label/ID inside the model config
     model.config.label2id = {l: i for i, l in enumerate(label_list)}
-    model.config.id2label = {i: l for i, l in enumerate(label_list)}  # TODO: careful if you want to cut the dataset
+    # TODO: careful if you want to cut the dataset
+    model.config.id2label = {i: l for i, l in enumerate(label_list)}
 
     # Map that sends B-Xxx label to its I-Xxx counterpart
     b_to_i_label = []
@@ -470,7 +471,7 @@ else:
         )
 
 
-print('taskcla: ',taskcla)
+print('taskcla: ', taskcla)
 
 # Log a few random samples from the training set:
 
@@ -484,7 +485,8 @@ for index in random.sample(range(len(train_dataset)), 1):
     logger.info(
         f"Sample {index} of the training set: {train_dataset[index]}. Decode to: {args.tokenizer.decode(train_dataset[index]['input_ids'])} and {args.tokenizer.decode(label)}")
 
-label_pad_token_id = -100 if args.ignore_pad_token_for_loss else args.tokenizer.pad_token_id
+label_pad_token_id = - \
+    100 if args.ignore_pad_token_for_loss else args.tokenizer.pad_token_id
 
 data_collator = DataCollatorForSeq2Seq(
     args.tokenizer,
@@ -495,27 +497,33 @@ data_collator = DataCollatorForSeq2Seq(
 )
 
 
-print('train_dataset: ',len(train_dataset))
+print('train_dataset: ', len(train_dataset))
 
-train_dataloader = DataLoader(train_dataset, shuffle=True, collate_fn=data_collator, batch_size=args.per_device_train_batch_size)
-dev_dataloader = DataLoader(dev_dataset, collate_fn=data_collator, batch_size=args.per_device_eval_batch_size)
-train_pool_loader = DataLoader(train_dataset, shuffle=True, collate_fn=data_collator, batch_size=args.per_device_train_pool_batch_size)
+train_dataloader = DataLoader(train_dataset, shuffle=True,
+                              collate_fn=data_collator, batch_size=args.per_device_train_batch_size)
+dev_dataloader = DataLoader(
+    dev_dataset, collate_fn=data_collator, batch_size=args.per_device_eval_batch_size)
+train_pool_loader = DataLoader(train_dataset, shuffle=True, collate_fn=data_collator,
+                               batch_size=args.per_device_train_pool_batch_size)
 
 # above train/dev done ======================================
-# bellow is tesitng, invovle different type of datasets and need different hyper-poarameters
+# bellow is testing, invovle different type of datasets and need different hyper-parameters
 
 
 test_loaders = []
-for eval_t in range(args.ft_task + 1): # last one is the current one
+for eval_t in range(args.ft_task + 1):  # last one is the current one
     test_dataset = datasets[eval_t]['test']
+    if 'ldbr' in args.baseline:
+        test_dataset = ldbr.process_dataset(test_dataset, args.tokenizer)
     args.task_name = args.all_tasks[eval_t]  # self.args.task_name has chaned
     if 'mix' in args.baseline and 'pool' in args.baseline:
-        args = utils.update_hyparameter_for_mix_pool(args) # update args for the hyper-parameters
+        args = utils.update_hyparameter_for_mix_pool(
+            args)  # update args for the hyper-parameters
     elif 'mix' in args.baseline:
-        args = utils.update_hyparameter_for_mix_norm(args) # update args for the hyper-parameters
-    print('args.task_name : ',args.task_name)
+        args = utils.update_hyparameter_for_mix_norm(
+            args)  # update args for the hyper-parameters
+    print('args.task_name : ', args.task_name)
     with accelerator.main_process_first():
-
         if args.task_name in args.ner_datasets:
             test_dataset = test_dataset.map(
                 tokenize_and_align_labels,
@@ -535,7 +543,6 @@ for eval_t in range(args.ft_task + 1): # last one is the current one
                 desc="Running tokenizer on dataset",
             )
 
-
     data_collator = DataCollatorForSeq2Seq(
         args.tokenizer,
         model=model,
@@ -544,10 +551,11 @@ for eval_t in range(args.ft_task + 1): # last one is the current one
         # important, you cannot set n_tokens to a random number then
     )
 
-    test_dataloader = DataLoader(test_dataset, collate_fn=data_collator, batch_size=args.per_device_eval_batch_size)
+    test_dataloader = DataLoader(
+        test_dataset, collate_fn=data_collator, batch_size=args.per_device_eval_batch_size)
     test_loaders.append(test_dataloader)
 
 
 appr = Appr(config, args)
-appr.train(model,train_dataloader,train_dataset,dev_dataloader,test_loaders,train_pool_loader,accelerator)
-
+appr.train(model, train_dataloader, train_dataset, dev_dataloader,
+           test_loaders, train_pool_loader, accelerator)

--- a/networks/bart.py
+++ b/networks/bart.py
@@ -198,7 +198,6 @@ class BartAttention(nn.Module):
         # if key_value_states are provided this layer is used as a cross-attention layer
         # for the decoder
         is_cross_attention = key_value_states is not None
-
         bsz, tgt_len, _ = hidden_states.size()
 
         # get query proj
@@ -1451,7 +1450,6 @@ class MyBartForConditionalGeneration(ModelWithHeadsAdaptersMixin, BartPretrained
 
         Returns:
         """
-
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:

--- a/networks/bart.py
+++ b/networks/bart.py
@@ -1745,7 +1745,8 @@ class MyBartForSequenceClassification(ModelWithHeadsAdaptersMixin, BartPretraine
         output_hidden_states=None,
         return_dict=None,
         task=None,
-        my_loss = None
+        my_loss = None,
+        nsp_labels=None
     ):
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
@@ -2017,7 +2018,8 @@ class MyBartForTokenClassification(ModelWithHeadsAdaptersMixin, BartPretrainedMo
         output_hidden_states=None,
         return_dict=None,
         my_loss=None,
-        task=None
+        task=None,
+        nsp_labels=None,
     ):
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):

--- a/networks/baselines/agem.py
+++ b/networks/baselines/agem.py
@@ -1,0 +1,42 @@
+import numpy as np
+import torch
+
+def project(gxy: torch.Tensor, ger: torch.Tensor) -> torch.Tensor:
+    corr = torch.dot(gxy, ger) / torch.dot(ger, ger)
+    return gxy - corr * ger
+
+def store_grad(params, grads, grad_dims):
+    """
+        This stores parameter gradients of past tasks.
+        pp: parameters
+        grads: gradients
+        grad_dims: list with number of parameters per layers
+    """
+    # store the gradients
+    grads.fill_(0.0)
+    count = 0
+    for param in params():
+        if param.grad is not None:
+            begin = 0 if count == 0 else sum(grad_dims[:count])
+            end = np.sum(grad_dims[:count + 1])
+            grads[begin: end].copy_(param.grad.data.view(-1))
+        count += 1
+
+
+def overwrite_grad(params, newgrad, grad_dims):
+    """
+        This is used to overwrite the gradients with a new gradient
+        vector, whenever violations occur.
+        pp: parameters
+        newgrad: corrected gradient
+        grad_dims: list storing number of parameters at each layer
+    """
+    count = 0
+    for param in params():
+        if param.grad is not None:
+            begin = 0 if count == 0 else sum(grad_dims[:count])
+            end = sum(grad_dims[:count + 1])
+            this_grad = newgrad[begin: end].contiguous().view(
+                param.grad.data.size())
+            param.grad.data.copy_(this_grad)
+        count += 1

--- a/networks/baselines/derpp.py
+++ b/networks/baselines/derpp.py
@@ -1,0 +1,47 @@
+from tqdm.auto import tqdm
+import torch
+import torch.distributed as dist
+import os
+
+
+def gather_importance(head_importance):
+    head_importance_list = [torch.zeros_like(head_importance) for _ in range(dist.get_world_size())]
+    dist.all_gather(tensor_list=head_importance_list, tensor=head_importance.contiguous()) # everyone need to do this
+    head_importance_list = torch.stack(head_importance_list)
+    head_importance = torch.mean(head_importance_list,dim=0)
+    return head_importance
+
+
+
+def derpp_compute(train_dataloader_prune, model, buffer, args):
+
+
+    buffer_path = os.path.join(args.output_dir, 'buffer')
+
+    with torch.no_grad():
+        total = args.buffer_size_per_dataset
+        for iteration in range(total // args.per_device_train_pool_batch_size + 1):
+            left = total - iteration * args.per_device_train_pool_batch_size
+            inputs = next(iter(train_dataloader_prune))# only one batch
+
+            if args.task_name in args.classification:
+                outputs = model.model(inputs['input_ids'], attention_mask=inputs['attention_mask'], labels=inputs['cls_labels'], output_hidden_states=True)
+                buffer.add_data(
+                    input_ids=inputs['input_ids'][:left],
+                    labels=inputs['cls_labels'][:left], 
+                    logits=outputs.hidden_states[-1][:left],
+                    attention_mask=inputs['attention_mask'][:left],
+                    task=inputs['task'][:left]
+                )
+            else:
+                outputs = model.model(inputs['input_ids'], attention_mask=inputs['attention_mask'], labels=inputs['labels'], output_hidden_states=True)
+                buffer.add_data(
+                    input_ids=inputs['input_ids'][:left], 
+                    labels=inputs['labels'][:left], 
+                    logits=outputs.hidden_states[-1][:left], 
+                    attention_mask=inputs['attention_mask'][:left],
+                    task=inputs['task'][:left]
+                )
+
+    print('buffer size: ',buffer.get_size())
+    torch.save(buffer, buffer_path)

--- a/networks/baselines/derpp.py
+++ b/networks/baselines/derpp.py
@@ -38,7 +38,7 @@ def derpp_compute(train_dataloader_prune, model, buffer, args):
                 buffer.add_data(
                     input_ids=inputs['input_ids'][:left], 
                     labels=inputs['labels'][:left], 
-                    logits=outputs.hidden_states[-1][:left], 
+                    logits=outputs.encoder_hidden_states[-1][:left], 
                     attention_mask=inputs['attention_mask'][:left],
                     task=inputs['task'][:left]
                 )

--- a/networks/baselines/dualprompt.py
+++ b/networks/baselines/dualprompt.py
@@ -1,0 +1,1151 @@
+from base64 import encode
+from turtle import forward
+import random
+from networks.bart import MyBartEncoder, MyBartEncoderLayer, _expand_mask, MyBartDecoder, MyBartModel, shift_tokens_right, MyOutput, MyBartForConditionalGeneration
+from networks.roberta import MyRobertaLayer, RobertaPreTrainedModel, BertModelAdaptersMixin, RobertaEmbeddings, RobertaPooler, ModelWithHeadsAdaptersMixin, RobertaClassificationHead
+import torch
+import torch.nn as nn
+from utils import utils
+import os
+from transformers.modeling_utils import apply_chunking_to_forward
+from transformers.adapters.composition import adjust_tensors_for_parallel
+from transformers.modeling_outputs import Seq2SeqModelOutput, BaseModelOutputWithPastAndCrossAttentions, BaseModelOutputWithPoolingAndCrossAttentions, SequenceClassifierOutput, TokenClassifierOutput, BaseModelOutput
+
+class DualPromptRobertaLayer(MyRobertaLayer):
+    def __init__(self, config, args, add_g_prompt=False, add_e_prompt=False):
+        super().__init__(config, args)
+        self.add_g_prompt = add_g_prompt
+        self.add_e_prompt = add_e_prompt
+    
+    def _cat_prompt_to_input(self, hidden_states, prompt_embeds):
+        """
+        Concatenates prompt embeddings to inputs (hidden states of the previous layer).
+        """
+
+        if len(list(hidden_states)) == 2:
+            hidden_states = hidden_states.unsqueeze(0)
+
+        hidden_states = torch.cat([prompt_embeds, hidden_states], dim=1)
+
+        return hidden_states
+
+    def _extend_attention_mask(self, attention_mask):
+        """
+        Extends attention_mask to match the input_ids's shape.
+        """
+
+        if len(list(attention_mask.shape)) == 1:
+            attention_mask = attention_mask.unsqueeze(0)
+
+        n_batches = attention_mask.shape[0]
+        return torch.cat(
+            [
+                torch.full(
+                    (n_batches, self.Lp * self.N), 1).to(
+                    attention_mask.device).long(),
+                attention_mask
+            ],
+            dim=1,
+        )
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask=None,
+        head_mask=None,
+        encoder_hidden_states=None,
+        encoder_attention_mask=None,
+        past_key_value=None,
+        output_attentions=False,
+        g_prompt=None,
+        e_prompt=None,
+        **kwargs
+    ):
+        # decoder uni-directional self-attention cached key/values tuple is at positions 1,2
+        self_attn_past_key_value = past_key_value[:2] if past_key_value is not None else None
+        if self.add_g_prompt and g_prompt is not None:
+            hidden_states = self._cat_prompt_to_input(hidden_states, g_prompt)
+            attention_mask = self._extend_attention_mask(attention_mask, g_prompt)
+        elif self.add_e_prompt and e_prompt is not None:
+            hidden_states = self._cat_prompt_to_input(hidden_states, e_prompt)
+            attention_mask = self._extend_attention_mask(attention_mask, e_prompt)
+        
+        self_attention_outputs = self.attention(
+            hidden_states,
+            attention_mask,
+            head_mask,
+            output_attentions=output_attentions,
+            past_key_value=self_attn_past_key_value,
+        )
+        attention_output = self_attention_outputs[0]
+
+        # if decoder, the last output is tuple of self-attn cache
+        if self.is_decoder:
+            outputs = self_attention_outputs[1:-1]
+            present_key_value = self_attention_outputs[-1]
+        else:
+            outputs = self_attention_outputs[1:]  # add self attentions if we output attention weights
+
+        cross_attn_present_key_value = None
+        if self.is_decoder and encoder_hidden_states is not None:
+            if not hasattr(self, "crossattention"):
+                raise ValueError(
+                    f"If `encoder_hidden_states` are passed, {self} has to be instantiated with cross-attention layers by setting `config.add_cross_attention=True`"
+                )
+
+            # cross_attn cached key/values tuple is at positions 3,4 of past_key_value tuple
+            cross_attn_past_key_value = past_key_value[-2:] if past_key_value is not None else None
+            cross_attention_outputs = self.crossattention(
+                attention_output,
+                attention_mask,
+                head_mask,
+                encoder_hidden_states,
+                encoder_attention_mask,
+                cross_attn_past_key_value,
+                output_attentions,
+            )
+            attention_output = cross_attention_outputs[0]
+            outputs = outputs + cross_attention_outputs[1:-1]  # add cross attentions if we output attention weights
+
+            # add cross-attn cache to positions 3,4 of present_key_value tuple
+            cross_attn_present_key_value = cross_attention_outputs[-1]
+            present_key_value = present_key_value + cross_attn_present_key_value
+
+        layer_output = apply_chunking_to_forward(
+            self.feed_forward_chunk, self.chunk_size_feed_forward, self.seq_len_dim, attention_output
+        )
+        outputs = (layer_output,) + outputs
+
+        # if decoder, return the attn key/values as the last output
+        if self.is_decoder:
+            outputs = outputs + (present_key_value,)
+
+        return outputs, attention_mask
+
+    def feed_forward_chunk(self, attention_output):
+        intermediate_output = self.intermediate(attention_output)
+        layer_output = self.output(intermediate_output, attention_output)
+        return layer_output
+
+
+class DualPromptRobertaEncoder(nn.Module):
+    def __init__(self, config, args, start_g, end_g, start_e, end_e):
+        """
+        We add G-Prompt to [start_g, end_g]th layers and add E-Prompt ot [start_e, end_t]th layers.
+        """
+        super().__init__()
+        self.config = config
+        self.args = args
+        self.layer = nn.ModuleList()
+        for i in range(config.num_hidden_layers):
+            add_g_prompt = True if start_g <= i <= end_g else False
+            add_e_prompt = True if start_e <= i <= end_e else False
+            self.layer.append(DualPromptRobertaLayer(config, args, add_g_prompt=add_g_prompt, add_e_prompt=add_e_prompt))
+
+        self.gradient_checkpointing = False
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask=None,
+        head_mask=None,
+        encoder_hidden_states=None,
+        encoder_attention_mask=None,
+        past_key_values=None,
+        use_cache=None,
+        output_attentions=False,
+        output_hidden_states=False,
+        return_dict=True,
+        g_prompt=None,
+        e_prompt=None,
+        **kwargs
+    ):
+        all_hidden_states = () if output_hidden_states else None
+        all_self_attentions = () if output_attentions else None
+        all_cross_attentions = () if output_attentions and self.config.add_cross_attention else None
+
+        next_decoder_cache = () if use_cache else None
+        for i, layer_module in enumerate(self.layer):
+            if output_hidden_states:
+                all_hidden_states = all_hidden_states + (hidden_states,)
+
+            layer_head_mask = head_mask[i] if head_mask is not None else None
+            past_key_value = past_key_values[i] if past_key_values is not None else None
+
+            if self.gradient_checkpointing and self.training:
+
+                def create_custom_forward(module):
+                    def custom_forward(*inputs):
+                        return module(*inputs, past_key_value, output_attentions)
+
+                    return custom_forward
+
+                layer_outputs = torch.utils.checkpoint.checkpoint(
+                    create_custom_forward(layer_module),
+                    hidden_states,
+                    attention_mask,
+                    layer_head_mask,
+                    encoder_hidden_states,
+                    encoder_attention_mask,
+                )
+            else:
+                layer_outputs, attention_mask = layer_module(
+                    hidden_states,
+                    attention_mask,
+                    layer_head_mask,
+                    encoder_hidden_states,
+                    encoder_attention_mask,
+                    past_key_value,
+                    output_attentions,
+                    g_prompt=g_prompt,
+                    e_prompt=e_prompt,
+                )
+
+            hidden_states = layer_outputs[0]
+            (attention_mask,) = adjust_tensors_for_parallel(hidden_states, attention_mask)
+
+            if use_cache:
+                next_decoder_cache += (layer_outputs[-1],)
+            if output_attentions:
+                all_self_attentions = all_self_attentions + (layer_outputs[1],)
+                if self.config.add_cross_attention:
+                    all_cross_attentions = all_cross_attentions + (layer_outputs[2],)
+
+        if output_hidden_states:
+            all_hidden_states = all_hidden_states + (hidden_states,)
+
+        if not return_dict:
+            return tuple(
+                v
+                for v in [
+                    hidden_states,
+                    next_decoder_cache,
+                    all_hidden_states,
+                    all_self_attentions,
+                    all_cross_attentions,
+                ]
+                if v is not None
+            )
+        return BaseModelOutputWithPastAndCrossAttentions(
+            last_hidden_state=hidden_states,
+            past_key_values=next_decoder_cache,
+            hidden_states=all_hidden_states,
+            attentions=all_self_attentions,
+            cross_attentions=all_cross_attentions,
+        )
+
+class DualPromptRobertaModel(BertModelAdaptersMixin, RobertaPreTrainedModel):
+    _keys_to_ignore_on_load_missing = [r"position_ids"]
+
+    # Copied from transformers.models.bert.modeling_bert.BertModel.__init__ with Bert->Roberta
+    def __init__(self, config, args, add_pooling_layer=True, start_g=1, end_g=2, start_e=3, end_e=5):
+        super().__init__(config)
+        self.config = config
+
+        self.embeddings = RobertaEmbeddings(config)
+        self.encoder = DualPromptRobertaEncoder(config, args, start_g, end_g, start_e, end_e)
+
+        self.pooler = RobertaPooler(config) if add_pooling_layer else None
+        self._init_adapter_modules()
+
+         # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embeddings.word_embeddings
+
+    def set_input_embeddings(self, value):
+        self.embeddings.word_embeddings = value
+
+    def _prune_heads(self, heads_to_prune):
+        """
+        Prunes heads of the model. heads_to_prune: dict of {layer_num: list of heads to prune in this layer} See base
+        class PreTrainedModel
+        """
+        for layer, heads in heads_to_prune.items():
+            self.encoder.layer[layer].attention.prune_heads(heads)
+
+    # Copied from transformers.models.bert.modeling_bert.BertModel.forward
+    def forward(
+            self,
+            input_ids=None,
+            attention_mask=None,
+            token_type_ids=None,
+            position_ids=None,
+            head_mask=None,
+            inputs_embeds=None,
+            encoder_hidden_states=None,
+            encoder_attention_mask=None,
+            past_key_values=None,
+            use_cache=None,
+            output_attentions=None,
+            output_hidden_states=None,
+            return_dict=None,
+            g_prompt=None,
+            e_prompt=None,
+            **kwargs
+    ):
+        r"""
+        encoder_hidden_states  (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
+            Sequence of hidden-states at the output of the last layer of the encoder. Used in the cross-attention if
+            the model is configured as a decoder.
+        encoder_attention_mask (`torch.FloatTensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Mask to avoid performing attention on the padding token indices of the encoder input. This mask is used in
+            the cross-attention if the model is configured as a decoder. Mask values selected in `[0, 1]`:
+            - 1 for tokens that are **not masked**,
+            - 0 for tokens that are **masked**.
+        past_key_values (`tuple(tuple(torch.FloatTensor))` of length `config.n_layers` with each tuple having 4 tensors of shape `(batch_size, num_heads, sequence_length - 1, embed_size_per_head)`):
+            Contains precomputed key and value hidden states of the attention blocks. Can be used to speed up decoding.
+            If `past_key_values` are used, the user can optionally input only the last `decoder_input_ids` (those that
+            don't have their past key value states given to this model) of shape `(batch_size, 1)` instead of all
+            `decoder_input_ids` of shape `(batch_size, sequence_length)`.
+        use_cache (`bool`, *optional*):
+            If set to `True`, `past_key_values` key value states are returned and can be used to speed up decoding (see
+            `past_key_values`).
+        """
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        if self.config.is_decoder:
+            use_cache = use_cache if use_cache is not None else self.config.use_cache
+        else:
+            use_cache = False
+
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
+        elif input_ids is not None:
+            input_shape = input_ids.size()
+        elif inputs_embeds is not None:
+            input_shape = inputs_embeds.size()[:-1]
+        else:
+            raise ValueError("You have to specify either input_ids or inputs_embeds")
+
+        batch_size, seq_length = input_shape
+        device = input_ids.device if input_ids is not None else inputs_embeds.device
+
+        # past_key_values_length
+        past_key_values_length = past_key_values[0][0].shape[2] if past_key_values is not None else 0
+
+        if attention_mask is None:
+            attention_mask = torch.ones(((batch_size, seq_length + past_key_values_length)), device=device)
+
+        if token_type_ids is None:
+            if hasattr(self.embeddings, "token_type_ids"):
+                buffered_token_type_ids = self.embeddings.token_type_ids[:, :seq_length]
+                buffered_token_type_ids_expanded = buffered_token_type_ids.expand(batch_size, seq_length)
+                token_type_ids = buffered_token_type_ids_expanded
+            else:
+                token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
+
+        # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
+        # ourselves in which case we just need to make it broadcastable to all heads.
+        extended_attention_mask: torch.Tensor = self.get_extended_attention_mask(attention_mask, input_shape, device)
+
+        # If a 2D or 3D attention mask is provided for the cross-attention
+        # we need to make broadcastable to [batch_size, num_heads, seq_length, seq_length]
+        if self.config.is_decoder and encoder_hidden_states is not None:
+            encoder_batch_size, encoder_sequence_length, _ = encoder_hidden_states.size()
+            encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
+            if encoder_attention_mask is None:
+                encoder_attention_mask = torch.ones(encoder_hidden_shape, device=device)
+            encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask)
+        else:
+            encoder_extended_attention_mask = None
+
+        # Prepare head mask if needed
+        # 1.0 in head_mask indicate we keep the head
+        # attention_probs has shape bsz x n_heads x N x N
+        # input head_mask has shape [num_heads] or [num_hidden_layers x num_heads]
+        # and head_mask is converted to shape [num_hidden_layers x batch x num_heads x seq_length x seq_length]
+        head_mask = self.get_head_mask(head_mask, self.config.num_hidden_layers)
+
+        embedding_output = self.embeddings(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            token_type_ids=token_type_ids,
+            inputs_embeds=inputs_embeds,
+            past_key_values_length=past_key_values_length,
+        )
+        embedding_output = self.invertible_adapters_forward(embedding_output)
+
+        encoder_outputs = self.encoder(
+            embedding_output,
+            attention_mask=extended_attention_mask,
+            head_mask=head_mask,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_extended_attention_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            g_prompt=g_prompt,
+            e_prompt=e_prompt,
+        )
+        sequence_output = encoder_outputs[0]
+        pooled_output = self.pooler(sequence_output) if self.pooler is not None else None
+
+        if not return_dict:
+            return (sequence_output, pooled_output) + encoder_outputs[1:]
+
+        return BaseModelOutputWithPoolingAndCrossAttentions(
+            last_hidden_state=sequence_output,
+            pooler_output=pooled_output,
+            past_key_values=encoder_outputs.past_key_values,
+            hidden_states=encoder_outputs.hidden_states,
+            attentions=encoder_outputs.attentions,
+            cross_attentions=encoder_outputs.cross_attentions,
+        )
+
+class DualPromptRobertaForSequenceClassification(ModelWithHeadsAdaptersMixin, RobertaPreTrainedModel):
+    def __init__(self, config, taskcla, args, tokenizer=None, Lg=5, Le=20, start_g=1, end_g=2, start_e=3, end_e=5):
+        """
+        G-Prompt: [Lg, embed_dim]
+        E-Prompt: {e_1, ..., e_T}, e_i [Le, embed_dim]
+        Learnable key (for task agnostic setting): {(k_1, e_1), ..., (k_T, e_T)}, k_i [last_hidden_dim]
+        """
+        super().__init__(config)
+        self.taskcla = taskcla
+        self.config = config
+        self.args = args
+        self.tokenizer = None
+        self.Lg = Lg
+        self.Le = Le
+        self.start_g = start_g
+        self.end_g = end_g
+        self.start_e = start_e
+        self.end_e = end_e
+        classifier_dropout = (
+            config.classifier_dropout if config.classifier_dropout is not None else config.hidden_dropout_prob
+        )
+        self.dropout = nn.Dropout(classifier_dropout)
+        self.roberta = DualPromptRobertaModel(config, args, add_pooling_layer=False,
+                                              start_g=start_g, end_g=end_g, start_e=start_e, end_e=end_e)
+
+        self.classifiers = nn.ModuleList()
+        for task, n in taskcla:
+            config.num_labels = n
+            self.classifiers.append(RobertaClassificationHead(config))
+
+        # G-Prompt, E-Prompt and learnable keys.
+        # We maintain {e_1, ..., e_T} as a large matrix of shape (T, Le * hidden_dim) for efficient look-up in task
+        # agnostic setting.
+        init_g_prompt_value = torch.FloatTensor(self.Lg, self.config.hidden_size).uniform_(-0.5, 0.5)
+        self.g_prompt = nn.Embedding(self.Lg, self.config.hidden_size)
+        self.g_prompt.weight = nn.parameter.Parameter(init_g_prompt_value)
+        init_e_prompts_value = torch.FloatTensor(self.args.ntasks, self.Le * self.config.hidden_size).uniform_(-0.5, 0.5)
+        self.e_prompts = nn.Embedding(self.args.ntasks, self.Le * self.config.hidden_size)
+        self.e_prompts.weight = nn.parameter.Parameter(init_e_prompts_value)
+        self.keys = nn.Embedding(self.args.ntasks, self.config.hidden_size)
+
+        # Hyperparameter for the loss function.
+        self.lam = 1.0  # Follow the original paper.
+
+    def _prepare_prompts(self, input_ids, task_id=None):
+        """
+        Prepare G-Prompt and E-Prompt according to task_id or matching function in task agnostic setting.
+        
+        If task_id = 0, we use cosine similarity for E-prompt selections; otherwise, we directly select E-Prompt with
+        task_id.
+        """
+        inputs_embeds = self.roberta.embeddings(input_ids)
+
+        if len(list(inputs_embeds)) == 2:
+            inputs_embeds = inputs_embeds.unsqueeze(0)
+
+        # Use the frozen pre-trained model to get the query features: q(x) = f(x)[0,:]
+        q = self.roberta(inputs_embeds=inputs_embeds)[0][:, 0, :]
+        if task_id is not None:
+            sim = utils.sim_matrix(q, self.keys.weight[task_id].reshape(1, -1))
+            e_prompt = self.e_prompts.weight[task_id].repeat(inputs_embeds.size(0), 1).reshape(
+                inputs_embeds.size(0), -1, self.config.hidden_size
+            )
+            matching_loss = sim.mean()
+        else:
+            sim = utils.sim_matrix(q, self.keys.weight)
+            selection = torch.topk(sim, 1, dim=1)
+            e_prompt = self.e_prompts.weight[selection.indices].reshape(
+                inputs_embeds.size(0), -1, self.config.hidden_size
+            )
+            matching_loss = selection.values.mean()
+
+        g_prompt = self.g_prompt.weight.repeat(inputs_embeds.size(0), 1, 1)
+
+        return inputs_embeds, g_prompt, e_prompt, matching_loss
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        token_type_ids=None,
+        position_ids=None,
+        head_mask=None,
+        inputs_embeds=None,
+        labels=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        task=None,
+        my_loss=None,
+        nsp_labels=None,
+        **kwargs
+    ):
+        r"""
+        labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+            Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,
+            config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
+            `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
+        """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        # for evaluation and training, it's assumed to use the same prompt within the batch.
+        inputs_embeds, g_prompt, e_prompt, matching_loss = self._prepare_prompts(input_ids)
+
+        outputs = self.roberta(
+            input_ids=None,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            g_prompt=g_prompt,
+            e_prompt=e_prompt,
+        )
+        sequence_output = outputs[0]
+        # logits = self.classifiers[self.args.task](sequence_output)
+        # self.num_labels = self.taskcla[self.args.task][1]
+
+        loss = 0
+        logits = None
+        if labels is not None and task is not None:
+            loss_fct = nn.CrossEntropyLoss()
+            logits = []
+            for t_id, t in enumerate(task):  # different task in the same batch
+                if self.args.is_transfer or self.args.is_reference:
+                    logit = self.readouts[self.args.eval_t][t](sequence_output[t_id].unsqueeze(0)) #no stack can be performed
+                else:
+                    logit = self.classifiers[t](sequence_output[t_id].unsqueeze(0)) #no stack can be performed
+                num_labels = self.taskcla[t][1]
+                cur_loss = loss_fct(logit.view(-1, num_labels), labels[t_id].view(-1))
+                loss += cur_loss
+                logits.append(logit)
+
+            if 'mtl' not in self.args.baseline and 'comb' not in self.args.baseline and 'agem' not in self.args.baseline and 'derpp' not in self.args.baseline:
+                # TODO: all replay methods should not calculate this.
+                logits = torch.cat(logits)
+
+            loss = loss / len(task)
+
+        else:
+            logits = []
+            for t in range(self.args.ntasks):
+                # [B, hidden] -> [B, labels]
+                logit = self.classifiers[t](sequence_output)
+                logits.append(logit)
+            logits = torch.cat(logits,dim=-1)
+
+        # Add matching loss.
+        loss += self.lam * matching_loss
+
+        if not return_dict:
+            output = (logits,) + outputs[2:]
+            return ((loss,) + output) if loss is not None else output
+
+        return SequenceClassifierOutput(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+class DualPromptRobertaForTokenClassification(DualPromptRobertaForSequenceClassification):
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        token_type_ids=None,
+        position_ids=None,
+        head_mask=None,
+        inputs_embeds=None,
+        labels=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        task=None,
+        my_loss=None,
+        nsp_labels=None,
+        **kwargs
+    ):
+        r"""
+        labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+            Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,
+            config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
+            `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
+        """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        # no replay, no multitask ! (we have to prepare different prompts for different task)
+        inputs_embeds, g_prompt, e_prompt, matching_loss = self._prepare_prompts(input_ids)
+
+        outputs = self.roberta(
+            input_ids=None,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            g_prompt=g_prompt,
+            e_prompt=e_prompt,
+        )
+        # adapt prompt to token classification !!
+        sequence_output = outputs[0][...,-self.args.max_length:,:]
+
+        sequence_output = self.dropout(sequence_output)
+        # logits = self.classifiers[self.args.task](sequence_output)
+        # self.num_labels = self.taskcla[self.args.task][1]
+
+        loss = 0
+        logits = None
+        if labels is not None and task is not None:
+            loss_fct = nn.CrossEntropyLoss()
+            logits = []
+            for t_id, t in enumerate(task):  # different task in the same batch
+                if self.args.is_transfer or self.args.is_reference:
+                    logit = self.readouts[self.args.eval_t][t](sequence_output[t_id].unsqueeze(0)) #no stack can be performed
+                else:
+                    logit = self.classifiers[t](sequence_output[t_id].unsqueeze(0)) #no stack can be performed
+                num_labels = self.taskcla[t][1]
+                cur_loss = loss_fct(logit.view(-1, num_labels), labels[t_id].view(-1))
+                loss += cur_loss
+                logits.append(logit)
+
+            if 'mtl' not in self.args.baseline and 'comb' not in self.args.baseline and 'agem' not in self.args.baseline and 'derpp' not in self.args.baseline:
+                # TODO: all replay methods should not calculate this.
+                logits = torch.cat(logits)
+
+            loss = loss / len(task)
+
+        else:
+            logits = []
+            for t in range(self.args.ntasks):
+                # [B, hidden] -> [B, labels]
+                logit = self.classifiers[t](sequence_output)
+                logits.append(logit)
+            logits = torch.cat(logits,dim=-1)
+
+        # Add matching loss.
+        loss += self.lam * matching_loss
+
+        if not return_dict:
+            output = (logits,) + outputs[2:]
+            return ((loss,) + output) if loss is not None else output
+
+        return TokenClassifierOutput(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+class DualPromptBartEncoderLayer(MyBartEncoderLayer):
+    def __init__(self, config, args, add_g_prompt=False, add_e_prompt=False):
+        super().__init__(config, args)
+        self.add_g_prompt = add_g_prompt
+        self.add_e_prompt = add_e_prompt
+    
+    def _cat_prompt_to_input(self, hidden_states, prompt_embeds):
+
+        if len(list(hidden_states)) == 2:
+            hidden_states = hidden_states.unsqueeze(0)
+        
+        hidden_states = torch.cat([prompt_embeds, hidden_states], dim=1)
+        return hidden_states
+    
+    def _extend_attention_mask(self, attention_mask, prompt_embeds):
+        
+        if len(list(attention_mask.shape)) == 1:
+            attention_mask = attention_mask.unsqueeze(0)
+        n_batches = attention_mask.shape[0]
+        n_tokens = prompt_embeds.shape[1]
+
+        tmp = torch.cat(
+            [
+                torch.full(
+                    (n_batches, 1, attention_mask.shape[-2], n_tokens), 1
+                ).to(attention_mask.device).long(),
+                attention_mask
+            ],
+            dim=-1
+        )
+
+        return torch.cat(
+            [
+                torch.full(
+                    (n_batches, 1, n_tokens, tmp.shape[-1]), 1).to(
+                    attention_mask.device).long(),
+                tmp
+            ],
+            dim=-2,
+        )
+    
+    def forward(
+        self,
+        hidden_states,
+        attention_mask,
+        layer_head_mask,
+        output_attentions=False,
+        teacher_encoder_hidden_state=None,
+        g_prompt=None,
+        e_prompt=None,
+        **kwargs
+    ):
+        if self.add_g_prompt and g_prompt is not None:
+            hidden_states = self._cat_prompt_to_input(hidden_states, g_prompt)
+            attention_mask = self._extend_attention_mask(attention_mask, g_prompt)
+        elif self.add_e_prompt and e_prompt is not None:
+            hidden_states = self._cat_prompt_to_input(hidden_states, e_prompt)
+            attention_mask = self._extend_attention_mask(attention_mask, e_prompt)
+
+        residual = hidden_states
+        hidden_states, attn_weights, _ = self.self_attn(
+                    hidden_states=hidden_states,
+                    attention_mask=attention_mask,
+                    layer_head_mask=layer_head_mask,
+                    output_attentions=output_attentions,
+                )
+        hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
+        hidden_states = self.attention_adapters(hidden_states, residual, 'encoder', self.self_attn_layer_norm) # TODO: seems set to ignore by adapter_transformer by default
+        residual = hidden_states
+        hidden_states = self.activation_fn(self.fc1(hidden_states))
+        hidden_states = nn.functional.dropout(hidden_states, p=self.activation_dropout, training=self.training)
+        hidden_states = self.fc2(hidden_states)
+        hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
+        hidden_states = self.output_adapters(hidden_states, residual, 'encoder' , self.final_layer_norm)
+
+
+        if hidden_states.dtype == torch.float16 and (
+            torch.isinf(hidden_states).any() or torch.isnan(hidden_states).any()
+        ):
+            clamp_value = torch.finfo(hidden_states.dtype).max - 1000
+            hidden_states = torch.clamp(hidden_states, min=-clamp_value, max=clamp_value)
+
+        outputs = (hidden_states,)
+
+        if output_attentions:
+            outputs += (attn_weights,)
+
+        return outputs, attention_mask
+
+class DualPromptBartEncoder(MyBartEncoder):
+    def __init__(self, config, start_g, end_g, start_e, end_e, embed_tokens=None, args=None):
+        super().__init__(config, embed_tokens, args)
+        self.layers = nn.ModuleList()
+        for i in range(config.encoder_layers):
+            add_g_prompt = True if start_g <= i <= end_g else False
+            add_e_prompt = True if start_e <= i <= end_e else False
+            self.layers.append(DualPromptBartEncoderLayer(config, args, add_g_prompt=add_g_prompt, add_e_prompt=add_e_prompt))
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        head_mask=None,
+        inputs_embeds=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        teacher_encoder_hidden_states=None,
+        g_prompt=None,
+        e_prompt=None,
+        **kwargs
+    ):
+
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        # retrieve input_ids and inputs_embeds
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
+        elif input_ids is not None:
+            input_shape = input_ids.size()
+            input_ids = input_ids.view(-1, input_shape[-1])
+        elif inputs_embeds is not None:
+            input_shape = inputs_embeds.size()[:-1]
+        else:
+            raise ValueError("You have to specify either input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids) * self.embed_scale
+
+        embed_pos = self.embed_positions(input_shape)
+
+        hidden_states = inputs_embeds + embed_pos
+        hidden_states = self.layernorm_embedding(hidden_states)
+        hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
+
+        hidden_states = self.invertible_adapters_forward(hidden_states)
+
+        # expand attention_mask
+        if attention_mask is not None:
+            # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
+            attention_mask = _expand_mask(attention_mask, inputs_embeds.dtype)
+
+        encoder_states = () if output_hidden_states else None
+        all_attentions = () if output_attentions else None
+
+        # check if head_mask has a correct number of layers specified if desired
+        if head_mask is not None:
+            if head_mask.size()[0] != (len(self.layers)):
+                raise ValueError(
+                    f"The head_mask should be specified for {len(self.layers)} layers, but it is for {head_mask.size()[0]}."
+                )
+
+        for idx, encoder_layer in enumerate(self.layers):
+            if output_hidden_states:
+                encoder_states = encoder_states + (hidden_states,)
+            # add LayerDrop (see https://arxiv.org/abs/1909.11556 for description)
+            dropout_probability = random.uniform(0, 1)
+            if self.training and (dropout_probability < self.layerdrop):  # skip the layer
+                layer_outputs = (None, None)
+            else:
+                if self.gradient_checkpointing and self.training:
+
+                    def create_custom_forward(module):
+                        def custom_forward(*inputs):
+                            return module(*inputs, output_attentions)
+
+                        return custom_forward
+
+                    layer_outputs = torch.utils.checkpoint.checkpoint(
+                        create_custom_forward(encoder_layer),
+                        hidden_states,
+                        attention_mask,
+                        (head_mask[idx] if head_mask is not None else None),
+                    )
+                else:
+
+                    if self.args.teacher_encoder_hidden_states is not None:
+                        layer_outputs = encoder_layer(
+                            hidden_states,
+                            attention_mask,
+                            layer_head_mask=(head_mask[idx] if head_mask is not None else None),
+                            output_attentions=output_attentions,
+                            teacher_encoder_hidden_state = self.args.teacher_encoder_hidden_states[idx],
+                            **kwargs
+                        )
+
+                    else:
+                        layer_outputs, attention_mask = encoder_layer(
+                            hidden_states,
+                            attention_mask,
+                            layer_head_mask=(head_mask[idx] if head_mask is not None else None),
+                            output_attentions=output_attentions,
+                            g_prompt=g_prompt,
+                            e_prompt=e_prompt,
+                            **kwargs
+                        )
+
+                hidden_states = layer_outputs[0]
+                (attention_mask,) = adjust_tensors_for_parallel(hidden_states, attention_mask)
+
+            if output_attentions:
+                all_attentions = all_attentions + (layer_outputs[1],)
+
+        if output_hidden_states:
+            encoder_states = encoder_states + (hidden_states,)
+        if not return_dict:
+            return tuple(v for v in [hidden_states, encoder_states, all_attentions, attention_mask] if v is not None)
+        return BaseModelOutput(
+            last_hidden_state=hidden_states, hidden_states=encoder_states, attentions=attention_mask
+        )
+
+class DualPromptBartModel(MyBartModel):
+
+    def __init__(self, config, args, start_g=1, end_g=2, start_e=3, end_e=5):
+        super().__init__(config, args)
+        self.encoder = DualPromptBartEncoder(config, start_g, end_g, start_e, end_e, self.shared, args)
+        self.decoder = MyBartDecoder(config, self.shared, args)
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        decoder_input_ids=None,
+        decoder_attention_mask=None,
+        head_mask=None,
+        decoder_head_mask=None,
+        cross_attn_head_mask=None,
+        encoder_outputs=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        decoder_inputs_embeds=None,
+        use_cache=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        g_prompt=None,
+        e_prompt=None,
+        **kwargs
+    ):
+        # different to other models, Bart automatically creates decoder_input_ids from
+        # input_ids if no decoder_input_ids are provided
+        if decoder_input_ids is None and decoder_inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError(
+                    "If no `decoder_input_ids` or `decoder_inputs_embeds` are "
+                    "passed, `input_ids` cannot be `None`. Please pass either "
+                    "`input_ids` or `decoder_input_ids` or `decoder_inputs_embeds`."
+                )
+
+            decoder_input_ids = shift_tokens_right(
+                input_ids, self.config.pad_token_id, self.config.decoder_start_token_id
+            )
+
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        if encoder_outputs is None:
+            encoder_outputs = self.encoder(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                head_mask=head_mask,
+                inputs_embeds=inputs_embeds,
+                output_attentions=output_attentions,
+                output_hidden_states=output_hidden_states,
+                return_dict=return_dict,
+                g_prompt=g_prompt,
+                e_prompt=e_prompt,
+                **kwargs
+            )
+            if attention_mask is not None:
+                attention_mask = torch.cat(
+                    [
+                        torch.full(
+                            (attention_mask.shape[0], encoder_outputs[-1].shape[-1]-attention_mask.shape[-1]), 1).to(
+                            attention_mask.device).long(),
+                        attention_mask
+                    ],
+                    dim=1,
+                )
+        # If the user passed a tuple for encoder_outputs, we wrap it in a BaseModelOutput when return_dict=True
+        elif return_dict and not isinstance(encoder_outputs, BaseModelOutput):
+            encoder_outputs = BaseModelOutput(
+                last_hidden_state=encoder_outputs[0],
+                hidden_states=encoder_outputs[1] if len(encoder_outputs) > 1 else None,
+                attentions=encoder_outputs[2] if len(encoder_outputs) > 2 else None,
+            )
+
+        # inflate all decoder inputs according to encoder output
+        decoder_input_ids, decoder_attention_mask, attention_mask = adjust_tensors_for_parallel(
+            encoder_outputs[0], decoder_input_ids, decoder_attention_mask, attention_mask
+        )
+        # decoder outputs consists of (dec_features, past_key_value, dec_hidden, dec_attn)
+        decoder_outputs = self.decoder(
+            input_ids=decoder_input_ids,
+            attention_mask=decoder_attention_mask,
+            encoder_hidden_states=encoder_outputs[0],
+            encoder_attention_mask=attention_mask,
+            head_mask=decoder_head_mask,
+            cross_attn_head_mask=cross_attn_head_mask,
+            past_key_values=past_key_values,
+            inputs_embeds=decoder_inputs_embeds,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            **kwargs
+        )
+
+        if not return_dict:
+            return decoder_outputs + encoder_outputs
+
+        return Seq2SeqModelOutput(
+            last_hidden_state=decoder_outputs.last_hidden_state,
+            past_key_values=decoder_outputs.past_key_values,
+            decoder_hidden_states=decoder_outputs.hidden_states,
+            decoder_attentions=decoder_outputs.attentions,
+            cross_attentions=decoder_outputs.cross_attentions,
+            encoder_last_hidden_state=encoder_outputs.last_hidden_state,
+            encoder_hidden_states=encoder_outputs.hidden_states,
+            encoder_attentions=encoder_outputs.attentions,
+        )
+
+class DualPromptBartForConditionalGeneration(MyBartForConditionalGeneration):
+
+    def __init__(self, config, taskcla, args, Lg=5, Le=20, start_g=1, end_g=2, start_e=3, end_e=5):
+        super().__init__(config, taskcla, args)
+        self.Lg = Lg
+        self.Le = Le
+        self.start_g = start_g
+        self.end_g = end_g
+        self.start_e = start_e
+        self.end_e = end_e
+        self.model = DualPromptBartModel(config, args, start_g, end_g, start_e, end_e)
+
+        init_g_prompt_value = torch.FloatTensor(self.Lg, self.config.d_model).uniform_(-0.5, 0.5)
+        self.g_prompt = nn.Embedding(self.Lg, self.config.d_model)
+        self.g_prompt.weight = nn.parameter.Parameter(init_g_prompt_value)
+        init_e_prompts_value = torch.FloatTensor(self.args.ntasks, self.Le * self.config.d_model).uniform_(-0.5, 0.5)
+        self.e_prompts = nn.Embedding(self.args.ntasks, self.Le * self.config.d_model)
+        self.e_prompts.weight = nn.parameter.Parameter(init_e_prompts_value)
+        self.keys = nn.Embedding(self.args.ntasks, self.config.d_model)
+
+        self.lam = 1.0
+
+    def get_prompt_extended_input_exclude_label(self,input_ids,attention_mask,labels):
+        inputs_embeds = self.model.shared(input_ids)
+
+        return inputs_embeds,attention_mask
+
+    def _prepare_prompts(self, input_ids, task_id=None):
+        
+        inputs_embeds = self.model.shared(input_ids)
+        if len(list(inputs_embeds)) == 2:
+            inputs_embeds = inputs_embeds.unsqueeze(0)
+        
+        q = self.model.encoder(inputs_embeds=inputs_embeds)[0][:, 0, :]
+        if task_id is not None:
+            sim = utils.sim_matrix(q, self.keys.weight[task_id].reshape(1, -1))
+            e_prompt = self.e_prompts.weight[task_id].repeat(inputs_embeds.size(0), 1).reshape(
+                inputs_embeds.size(0), -1, self.config.d_model
+            )
+            matching_loss = sim.mean()
+        else:
+            sim = utils.sim_matrix(q, self.keys.weight)
+            selection = torch.topk(sim, 1, dim=1)
+            e_prompt = self.e_prompts.weight[selection.indices].reshape(
+                inputs_embeds.size(0), -1, self.config.d_model
+            )
+            matching_loss = selection.values.mean()
+        
+        g_prompt = self.g_prompt.weight.repeat(inputs_embeds.size(0), 1, 1)
+
+        return inputs_embeds, g_prompt, e_prompt, matching_loss
+    
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        decoder_input_ids=None,
+        decoder_attention_mask=None,
+        head_mask=None,
+        decoder_head_mask=None,
+        cross_attn_head_mask=None,
+        encoder_outputs=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        decoder_inputs_embeds=None,
+        labels=None,
+        use_cache=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        my_loss = None,
+        **kwargs
+    ):
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        # for evaluation and training, it's assumed to use the same prompt within the batch.
+        inputs_embeds, g_prompt, e_prompt, matching_loss = self._prepare_prompts(input_ids)
+        if labels is not None:
+            
+            use_cache = False
+
+            if decoder_input_ids is None and decoder_inputs_embeds is None:
+                decoder_input_ids = shift_tokens_right(
+                    labels, self.config.pad_token_id, self.config.decoder_start_token_id
+                )
+        
+        if self.args.is_transfer:
+            with torch.no_grad():
+                outputs = self.model(
+                    input_ids=None,
+                    attention_mask=attention_mask,
+                    decoder_input_ids=decoder_input_ids,
+                    encoder_outputs=encoder_outputs,
+                    decoder_attention_mask=decoder_attention_mask,
+                    head_mask=head_mask,
+                    decoder_head_mask=decoder_head_mask,
+                    cross_attn_head_mask=cross_attn_head_mask,
+                    past_key_values=past_key_values,
+                    inputs_embeds=inputs_embeds,
+                    decoder_inputs_embeds=decoder_inputs_embeds,
+                    use_cache=use_cache,
+                    output_attentions=output_attentions,
+                    output_hidden_states=output_hidden_states,
+                    return_dict=return_dict,
+                    g_prompt=g_prompt,
+                    e_prompt=e_prompt,
+                    **kwargs
+                )
+
+        else:
+            outputs = self.model(
+                input_ids=None,
+                attention_mask=attention_mask,
+                decoder_input_ids=decoder_input_ids,
+                encoder_outputs=encoder_outputs,
+                decoder_attention_mask=decoder_attention_mask,
+                head_mask=head_mask,
+                decoder_head_mask=decoder_head_mask,
+                cross_attn_head_mask=cross_attn_head_mask,
+                past_key_values=past_key_values,
+                inputs_embeds=inputs_embeds,
+                decoder_inputs_embeds=decoder_inputs_embeds,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                output_hidden_states=output_hidden_states,
+                return_dict=return_dict,
+                g_prompt=g_prompt,
+                e_prompt=e_prompt,
+                **kwargs
+            )
+        
+        lm_logits = self.model.encoder.invertible_adapters_forward(outputs[0], rev=True)
+        if self.args.is_transfer:
+            lm_logits = self.readouts[self.args.eval_t](lm_logits) + self.final_logits_bias
+        else:
+            lm_logits = self.lm_head(lm_logits) + self.final_logits_bias
+        
+        masked_lm_loss = matching_loss * self.lam
+
+        if labels is not None:
+            loss_fct = nn.CrossEntropyLoss()
+            masked_lm_loss = loss_fct(lm_logits.view(-1, self.config.vocab_size), labels.view(-1))
+
+
+        if my_loss is not None:
+            masked_lm_loss += my_loss
+
+        if not return_dict:
+            output = (lm_logits,) + outputs[1:]
+            return ((masked_lm_loss,) + output) if masked_lm_loss is not None else output
+        
+        return MyOutput(
+            loss=masked_lm_loss,
+            logits=lm_logits,
+            past_key_values=outputs.past_key_values,
+            decoder_hidden_states=outputs.decoder_hidden_states,
+            decoder_attentions=outputs.decoder_attentions,
+            cross_attentions=outputs.cross_attentions,
+            encoder_last_hidden_state=outputs.encoder_last_hidden_state,
+            encoder_hidden_states=outputs.encoder_hidden_states,
+            encoder_attentions=outputs.encoder_attentions,
+            last_hidden_state=outputs.last_hidden_state
+        )

--- a/networks/baselines/dytox.py
+++ b/networks/baselines/dytox.py
@@ -1,0 +1,177 @@
+from fileinput import close
+import math
+import torch
+import torch.nn as nn
+import numpy as np
+import json
+from networks.roberta import MyRobertaForSequenceClassification
+from transformers.modeling_outputs import SequenceClassifierOutput
+
+class RobertaClassificationHeadDyTox(nn.Module):
+    """Head for sentence-level classification tasks."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+        classifier_dropout = (
+            config.classifier_dropout if config.classifier_dropout is not None else config.hidden_dropout_prob
+        )
+        self.dropout = nn.Dropout(classifier_dropout)
+        self.out_proj = nn.Linear(config.hidden_size, config.num_labels)
+
+    def forward(self, features, **kwargs):
+        x = features
+        x = self.dropout(x)
+        x = self.dense(x)
+        x = torch.tanh(x)
+        x = self.dropout(x)
+        x = self.out_proj(x)
+        return x
+
+class DyToxTAB(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        
+        self.num_attention_heads = config.num_attention_heads
+        self.attention_head_size = int(config.hidden_size / config.num_attention_heads)
+        self.all_head_size = self.num_attention_heads * self.attention_head_size
+
+        self.query = nn.Linear(config.hidden_size, self.all_head_size)
+        self.key = nn.Linear(config.hidden_size, self.all_head_size)
+        self.value = nn.Linear(config.hidden_size, self.all_head_size)
+
+    def transpose_for_scores(self, x):
+        new_x_shape = x.size()[:-1] + (self.num_attention_heads, self.attention_head_size)
+        x = x.view(new_x_shape)
+        return x.permute(0, 2, 1, 3)
+
+    def forward(
+        self,
+        theta,
+        x,
+    ):
+        '''
+            x: [batch_size, seq_len, hidden_size]
+            theta: [batch_size, hidden_size] 
+            z: [batch_Size, seq_len+1, hidden_size]
+            query_layer: [batch_size, 1, head_num, head_size]
+            key, value_layer: [batch_size, seq_len+1, head_num, head_size]
+            atten_probs: [batch_size, 1, head_num, head_num]
+            context_layer: [batch_size, 1, head_num, head_size] -> [batch_size, 1, all_head_size]
+        '''
+        theta = theta.unsqueeze(1)
+        z = torch.cat([x, theta], dim=1)
+
+        query_layer = self.transpose_for_scores(self.query(theta))
+        key_layer = self.transpose_for_scores(self.key(z))  
+        value_layer = self.transpose_for_scores(self.value(z))
+        
+        # Take the dot product between "query" and "key" to get the raw attention scores.
+        attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
+        attention_scores = attention_scores / math.sqrt(self.attention_head_size)
+
+        # Normalize the attention scores to probabilities.
+        attention_probs = nn.functional.softmax(attention_scores, dim=-1)
+
+        context_layer = torch.matmul(attention_probs, value_layer)
+        context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
+        new_context_layer_shape = context_layer.size()[:-2] + (self.all_head_size,)
+        context_layer = context_layer.view(new_context_layer_shape)
+
+        outputs = context_layer
+        return outputs.squeeze(1)
+
+class MyRobertaForSequenceClassificationDyTox(MyRobertaForSequenceClassification):
+    def __init__(self, config, taskcla, args, **kwargs):
+        super().__init__(config, taskcla, args)
+        self.taskcla = taskcla
+        self.config = config
+        self.args = args
+        ## self.roberta is SAB, self.classifiers is clf
+        self.task_embedder = nn.Embedding(args.ntasks, config.hidden_size)
+        self.TAB = DyToxTAB(config)
+        self.classifiers = nn.ModuleList() # overwrite !!
+        for _, n in taskcla:
+            config.num_labels = n
+            classifier = RobertaClassificationHeadDyTox(config)
+            self.classifiers.append(classifier)
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        token_type_ids=None,
+        position_ids=None,
+        head_mask=None,
+        inputs_embeds=None,
+        labels=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        task=None,
+        my_loss=None,
+        nsp_labels=None,
+    ):
+
+        r"""
+        labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+            Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,
+            config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
+            `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
+        """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        
+        outputs = self.roberta(
+            input_ids,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+        
+        if task is not None:
+            theta = self.task_embedder(task)
+        else:
+            theta = self.task_embedder(torch.ones(input_ids.size(0), device=input_ids.device) * self.ft_task)
+
+        sequence_output = self.TAB(theta=theta, x=outputs[0])   # outputs should be the same as 
+
+        loss = 0
+        logits = None
+
+        if labels is not None and task is not None:
+            loss_fct = nn.CrossEntropyLoss()
+            logits = []
+            for t_id, t in enumerate(task):  # different task in the same batch
+                logit = self.classifiers[t](sequence_output[t_id].unsqueeze(0)) #no stack can be performed
+                num_labels = self.taskcla[t][1]
+                cur_loss = loss_fct(logit.view(-1, num_labels), labels[t_id].view(-1))
+                loss += cur_loss
+                logits.append(logit)
+
+            if 'mtl' not in self.args.baseline and 'comb' not in self.args.baseline:
+                logits = torch.cat(logits)
+
+            loss = loss / len(task)
+
+        else:
+            logits = []
+            for t in range(self.args.ntasks):
+                logit = self.classifiers[t](sequence_output)
+                logits.append(logit)
+            logits = torch.cat(logits,dim=1)
+
+
+        if my_loss is not None:
+            loss += my_loss
+
+        return SequenceClassifierOutput(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )

--- a/networks/baselines/ewc.py
+++ b/networks/baselines/ewc.py
@@ -8,7 +8,7 @@ import os
 from utils import utils
 import math
 
-def compute(train_dataloader_prune,model,self_fisher,accelerator,args):
+def compute(train_dataloader_prune, model, self_fisher, accelerator, args):
     fisher_path = os.path.join(args.output_dir, 'fisher')
 
     if args.ft_task > 0:
@@ -74,7 +74,7 @@ def compute(train_dataloader_prune,model,self_fisher,accelerator,args):
 
 #TODO: incorrect === error
 
-def loss_compute(my_model,self_fisher):
+def loss_compute(my_model, self_fisher):
     loss_reg = 0
     if my_model.args.ft_task > 0:
 

--- a/networks/baselines/l2p.py
+++ b/networks/baselines/l2p.py
@@ -3,10 +3,9 @@ import torch
 import torch.nn as nn
 from networks.bart import MyBartForConditionalGeneration,MyBartForSequenceClassification,MyBartForTokenClassification
 from networks.bart import shift_tokens_right
-from networks.prompt.tuning import BARTPromptTuningMixinCommon
+from networks.roberta import MyRobertaForSequenceClassification, MyRobertaForTokenClassification
+from networks.prompt.tuning import BARTPromptTuningMixinCommon, RobertaPromptTuningMixinCommon
 from utils import utils
-
-
 
 
 class BARTL2PMixinConditionalGneration(BARTPromptTuningMixinCommon):
@@ -41,7 +40,6 @@ class BARTL2PMixinConditionalGneration(BARTPromptTuningMixinCommon):
         """
         Extends attention_mask to match the input_ids's shape.
         """
-
         if len(list(attention_mask.shape)) == 1:
             attention_mask = attention_mask.unsqueeze(0)
 
@@ -113,7 +111,91 @@ class BARTL2PMixinConditionalGneration(BARTPromptTuningMixinCommon):
             **kwargs
         )
 
+class RobertaL2PMixinClassification(RobertaPromptTuningMixinCommon):
+    def _cat_selected_prompt_to_input(self, input_ids):
+        """
+        Selects prompts which minimize the matching function and concatenates them to the inputs.
+        x_p = [P_s1; ... ; P_sN; x_e]
+        """
+        inputs_embeds = self.roberta.embeddings.word_embeddings(input_ids)
 
+        if len(list(inputs_embeds)) == 2:
+            inputs_embeds = inputs_embeds.unsqueeze(0)
+
+        # Use the frozen pre-trained model to get the query features: q(x) = f(x)[0,:]
+        q = self.roberta(inputs_embeds=inputs_embeds)[0][:, 0, :]
+        sim = utils.sim_matrix(q, self.keys.weight)
+        selection = torch.topk(sim, self.N, dim=1)
+        matching_loss = selection.values.sum(dim=1).mean()
+        selected_prompt = self.prompt_pool.weight[selection.indices].reshape(
+            -1, self.Lp * self.N, self.config.hidden_size).to(input_ids.device)
+
+        inputs_embeds = torch.cat([selected_prompt, inputs_embeds], dim=1)
+
+        return inputs_embeds, matching_loss
+
+    def _extend_attention_mask(self, attention_mask):
+        """
+        Extends attention_mask to match the input_ids's shape.
+        """
+
+        if len(list(attention_mask.shape)) == 1:
+            attention_mask = attention_mask.unsqueeze(0)
+
+        n_batches = attention_mask.shape[0]
+        return torch.cat(
+            [
+                torch.full(
+                    (n_batches, self.Lp * self.N), 1).to(
+                    attention_mask.device).long(),
+                attention_mask
+            ],
+            dim=1,
+        )
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        token_type_ids=None,
+        position_ids=None,
+        head_mask=None,
+        inputs_embeds=None,
+        labels=None,
+        output_attentions=None,
+        output_hidden_states=True,
+        return_dict=None,
+        my_loss=None,
+        task=None,
+        nsp_labels=None
+    ):
+
+
+        if input_ids is not None:
+            inputs_embeds, matching_loss = self._cat_selected_prompt_to_input(input_ids)
+            matching_loss = self.lam * matching_loss
+
+
+        if attention_mask is not None:
+            attention_mask = self._extend_attention_mask(attention_mask)
+
+        # Drop most of the args for now
+        return super().forward(
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            input_ids=None,
+            head_mask=head_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            task=task,
+            my_loss=matching_loss,
+            nsp_labels=nsp_labels
+        )
+    
 class BARTL2PMixinClassification(BARTPromptTuningMixinCommon):
 
     def _cat_selected_prompt_to_input(self, input_ids):
@@ -435,6 +517,51 @@ class MyBartForConditionalGenerationSoftL2P(BARTL2PMixinConditionalGneration, My
     def __init__(self, config, taskcla, args, **kwargs):
         BARTL2PMixinConditionalGneration.__init__(self)
         MyBartForConditionalGeneration.__init__(self, config, taskcla, args, **kwargs)
+
+        """
+        Prompt pool (P): {P_1, ..., P_M}, P_i [Lp, embed_dim]
+        Learnable key: {(k_1, P_1), ..., (k_M, P_M)}, k_i [last_hidden_dim]
+        """
+
+        self.taskcla = taskcla
+        self.config = config
+        self.args = args
+        self.tokenizer = None
+        self.M = args.M
+        self.N = args.N
+        self.Lp = args.Lp
+        self.keys = nn.Embedding(self.M, self.config.hidden_size)
+
+        # Hyperparameter for the loss function.
+        self.lam = 0.5  # Follow the original paper.
+
+
+class MyRobertaForTokenClassificationSoftL2P(RobertaL2PMixinClassification, MyRobertaForTokenClassification):
+    def __init__(self, config, taskcla, args, **kwargs):
+        RobertaL2PMixinClassification.__init__(self)
+        MyRobertaForTokenClassification.__init__(self, config, taskcla, args, **kwargs)
+
+        """
+        Prompt pool (P): {P_1, ..., P_M}, P_i [Lp, embed_dim]
+        Learnable key: {(k_1, P_1), ..., (k_M, P_M)}, k_i [last_hidden_dim]
+        """
+
+        self.taskcla = taskcla
+        self.config = config
+        self.args = args
+        self.tokenizer = None
+        self.M = args.M
+        self.N = args.N
+        self.Lp = args.Lp
+        self.keys = nn.Embedding(self.M, self.config.hidden_size)
+
+        # Hyperparameter for the loss function.
+        self.lam = 0.5  # Follow the original paper.
+
+class MyRobertaForSequenceClassificationSoftL2P(RobertaL2PMixinClassification, MyRobertaForSequenceClassification):
+    def __init__(self, config, taskcla, args, **kwargs):
+        RobertaL2PMixinClassification.__init__(self)
+        MyRobertaForSequenceClassification.__init__(self, config, taskcla, args, **kwargs)
 
         """
         Prompt pool (P): {P_1, ..., P_M}, P_i [Lp, embed_dim]

--- a/networks/baselines/ldbr.py
+++ b/networks/baselines/ldbr.py
@@ -1,0 +1,260 @@
+from fileinput import close
+import math
+import torch
+import torch.nn as nn
+import numpy as np
+import json
+from sklearn.cluster import KMeans, MiniBatchKMeans
+from networks.roberta import MyRobertaForSequenceClassification
+from transformers.modeling_outputs import SequenceClassifierOutput
+
+
+class RobertaClassificationHeadLDBR(nn.Module):
+    """Head for sentence-level classification tasks."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.dense = nn.Linear(128 * 2, config.hidden_size)
+        classifier_dropout = (
+            config.classifier_dropout if config.classifier_dropout is not None else config.hidden_dropout_prob
+        )
+        self.dropout = nn.Dropout(classifier_dropout)
+        self.out_proj = nn.Linear(config.hidden_size, config.num_labels)
+
+    def forward(self, features, **kwargs):
+        x = features
+        x = self.dropout(x)
+        x = self.dense(x)
+        x = torch.tanh(x)
+        x = self.dropout(x)
+        x = self.out_proj(x)
+        return x
+
+class MyRobertaForSequenceClassificationLDBR(MyRobertaForSequenceClassification):
+    def __init__(self, config, taskcla, args, **kwargs):
+        super().__init__(config, taskcla, args)
+        self.taskcla = taskcla
+        self.config = config
+        self.args = args
+        self.G = nn.Sequential(
+            nn.Linear(config.hidden_size, 128),
+            nn.Tanh(),
+        )
+        self.S = nn.Sequential(
+            nn.Linear(config.hidden_size, 128),
+            nn.Tanh()
+        )
+        # Task id predictor, different from self.classfiers
+        self.task_classifier = nn.Linear(128, args.ntasks)
+        self.nsp_classifier = nn.Linear(128, args.ntasks)
+        self.classifiers = nn.ModuleList() # overwrite !!
+        for task, n in taskcla:
+            config.num_labels = n
+            classifier = RobertaClassificationHeadLDBR(config )
+            self.classifiers.append(classifier)
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        token_type_ids=None,
+        position_ids=None,
+        head_mask=None,
+        inputs_embeds=None,
+        labels=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        task=None,
+        my_loss=None,
+        nsp_labels=None,
+    ):
+
+        r"""
+        labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+            Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,
+            config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
+            `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
+        """
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        
+
+        outputs = self.roberta(
+            input_ids,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+        
+        sequence_output = outputs[0][:,0,:]
+        outputs.hidden_states = outputs[0][:,0,:]
+
+        loss = 0
+        logits = None
+
+        ## for ldbr, we must provide task id to do Task Id prediction!!!
+        general_knowledge = self.G(sequence_output)
+        specific_knowledge = self.S(sequence_output) # size = (B, 128)
+        total_knowledge = torch.cat([general_knowledge, specific_knowledge], dim=-1) # (B, 256)
+        loss_fct = nn.CrossEntropyLoss()
+        logits = []
+        if labels is not None and task is not None:
+            for t_id, t in enumerate(task):  # different task in the same batch
+                logit = self.classifiers[t](total_knowledge[t_id].unsqueeze(0))
+                num_labels = self.taskcla[t][1]
+                cur_loss = loss_fct(logit.view(-1, num_labels), labels[t_id].view(-1))
+                loss += cur_loss
+                logits.append(logit)
+
+            task_predict_logit = self.task_classifier(specific_knowledge)
+            specific_loss = loss_fct(task_predict_logit.view(-1, self.args.ntasks), task.view(-1))
+            loss += specific_loss
+        else:
+            logits = []
+            for t in range(self.args.ntasks):
+                logit = self.classifiers[t](total_knowledge)
+                logits.append(logit)
+
+        logits = (logits, specific_knowledge, general_knowledge)
+
+        if nsp_labels is not None:
+            nsp_logits = self.nsp_classifier(general_knowledge)
+            general_loss = loss_fct(nsp_logits.view(-1, self.args.ntasks), nsp_labels.long().view(-1))
+            loss += general_loss
+
+        if my_loss is not None:
+            loss += my_loss
+
+        return SequenceClassifierOutput(
+            loss=loss / input_ids.shape[0],
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+    
+def regularization(ouputs, teacher_outputs):
+    # TODO: the name "logits" is not suitable, actually they are hidden representations
+    g_outputs, s_outputs = ouputs.logits[-1], ouputs.logits[-2]
+    g_teacher_outputs, s_teacher_outputs = teacher_outputs.logits[-1], teacher_outputs.logits[-2]
+    loss_func = nn.MSELoss()
+    return (loss_func(g_outputs, g_teacher_outputs) + loss_func(s_outputs, s_teacher_outputs)) * 0.5
+
+
+def select_samples_to_store(model, buffer, data_loader, task_id):
+
+    x_list = []
+    mask_list = []
+    y_list = []
+    fea_list = []
+    nsp_list = []
+
+    model.eval()
+    with torch.no_grad():
+        for inputs in data_loader:
+            x = inputs['input_ids']
+            mask = inputs['attention_mask']
+            y = inputs['cls_labels']
+            nsp_labels = inputs['nsp_labels']
+            x = x.cuda()
+            mask = mask.cuda()
+            y = y.cuda()
+            outputs = model(
+                input_ids = x, 
+                attention_mask = mask,
+            )
+            roberta_emb = outputs.hidden_states
+            x_list.append(x.to("cpu"))
+            mask_list.append(mask.to("cpu"))
+            y_list.append(y.to("cpu"))
+            nsp_list.append(nsp_labels.to('cpu'))
+            # Kmeans on bert embedding
+            fea_list.append(roberta_emb.to("cpu"))
+    x_list = torch.cat(x_list, dim=0).data.cpu().numpy()
+    mask_list = torch.cat(mask_list, dim=0).data.cpu().numpy()
+    y_list = torch.cat(y_list, dim=0).data.cpu().numpy()
+    fea_list = torch.cat(fea_list, dim=0).data.cpu().numpy()
+    nsp_list = torch.cat(nsp_list, dim=0).data.cpu().numpy()
+    n_clu = model.args.buffer_size_per_dataset
+    estimator = KMeans(n_clusters=n_clu, random_state=2022)
+    estimator.fit(fea_list)
+    label_pred = estimator.labels_
+    centroids = estimator.cluster_centers_
+
+    examples = []
+    labels = []
+    attention_mask = []
+    task = []
+    nsp_labels = []
+    for clu_id in range(n_clu):
+        index = [i for i in range(len(label_pred)) if label_pred[i] == clu_id]
+        closest = float("inf")
+        closest_x = None
+        closest_mask = None
+        closest_y = None
+        closest_nsp_label = None
+        for j in index:
+            dis = np.sqrt(np.sum(np.square(centroids[clu_id] - fea_list[j])))
+            if dis < closest:
+                closest_x = x_list[j]
+                closest_mask = mask_list[j]
+                closest_y = y_list[j]
+                closest_nsp_label = nsp_list[j]
+                closest = dis
+
+        if closest_x is not None:
+            examples.append(closest_x)
+            labels.append(closest_y)
+            attention_mask.append(closest_mask)
+            task.append(task_id)
+            nsp_labels.append(closest_nsp_label)
+
+    buffer.add_data(
+        torch.tensor(examples).to(buffer.device), 
+        attention_mask=torch.tensor(attention_mask).to(buffer.device), 
+        labels=torch.tensor(labels).to(buffer.device), 
+        task=torch.tensor(task).to(buffer.device),
+        nsp_labels=torch.tensor(nsp_labels).to(buffer.device)
+    )
+    
+    print("Buffer size:{}".format(len(buffer)))
+
+def process_dataset(dataset, tokenizer):
+    import random
+    def process_one(inp):
+        sent = inp.split(' ')
+        sep_token = tokenizer.sep_token
+        if sep_token in sent: # asc
+            sep_place = sent.index(sep_token)
+        else:
+            sep_place = len(sent) - 1
+        if sep_place == 1:
+            ## nsp requires sentence length more than 1 !!!!
+            sent = [sent[0], tokenizer.sep_token, sent[1], sent[2]]
+            sep_place = 2
+            
+        place = random.randint(1, sep_place - 1)
+        mask = random.random() > 0.5
+        
+        if mask:    # label = 1, normal sequence
+            sent = sent[:place] + [tokenizer.sep_token] + sent[place:sep_place] + sent[sep_place:]
+        else:       # label = 0, abnormal sequence
+            sent = sent[place:sep_place] + [tokenizer.sep_token] + sent[:place] + sent[sep_place:]
+        
+        inp = ' '.join(inp)
+        return inp, mask
+
+    inputs, nsp_label = [], []
+    for sent in dataset['source']:
+        inp, mask = process_one(sent)
+        inputs.append(inp)
+        nsp_label.append(mask)
+
+    dataset = dataset.add_column("nsp_labels", nsp_label)
+    dataset = dataset.remove_columns('source')
+    dataset = dataset.add_column("source", inputs)
+    return dataset

--- a/networks/bert.py
+++ b/networks/bert.py
@@ -1387,7 +1387,8 @@ class MyBertForSequenceClassification(ModelWithHeadsAdaptersMixin, BertPreTraine
         output_hidden_states=None,
         return_dict=None,
         task=None,
-        my_loss=None
+        my_loss=None,
+        nsp_labels=None
     ):
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):

--- a/networks/buffer.py
+++ b/networks/buffer.py
@@ -1,0 +1,166 @@
+# Copyright 2020-present, Pietro Buzzega, Matteo Boschini, Angelo Porrello, Davide Abati, Simone Calderara.
+# All rights reserved.
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import numpy as np
+from typing import Tuple, Dict
+from torchvision import transforms
+
+
+def reservoir(num_seen_examples: int, buffer_size: int) -> int:
+    """
+    Reservoir sampling algorithm.
+    :param num_seen_examples: the number of seen examples
+    :param buffer_size: the maximum buffer size
+    :return: the target index if the current image is sampled, else -1
+    """
+    if num_seen_examples < buffer_size:
+        return num_seen_examples
+
+    rand = np.random.randint(0, num_seen_examples + 1)
+    if rand < buffer_size: #total batch size
+        return rand
+    else:
+        return -1
+
+
+def ring(num_seen_examples: int, buffer_portion_size: int, task: int) -> int:
+    return num_seen_examples % buffer_portion_size + task * buffer_portion_size
+
+
+class Buffer:
+    """
+    The memory buffer of rehearsal method.
+    """
+    def __init__(self, buffer_size, device, n_tasks=None, mode='reservoir'):
+        assert mode in ['ring', 'reservoir']
+        self.buffer_size = buffer_size
+        self.device = device
+        self.num_seen_examples = 0
+        self.functional_index = eval(mode)
+        if mode == 'ring':
+            assert n_tasks is not None
+            self.task_number = n_tasks
+            self.buffer_portion_size = buffer_size // n_tasks
+        self.attributes = ['input_ids', 'labels', 'logits', 'attention_mask', 'task', 'nsp_labels']
+
+    def init_tensors(self,
+                    input_ids: torch.Tensor,
+                    labels: torch.Tensor,
+                    logits: torch.Tensor,
+                    attention_mask: torch.Tensor,
+                    task: torch.Tensor,
+                    nsp_labels: torch.Tensor) -> None:
+
+        for attr_str in self.attributes:
+            attr = eval(attr_str)
+            if attr is not None and not hasattr(self, attr_str):
+                typ = torch.float32 if attr_str.endswith('gits') else torch.int64
+                setattr(self, attr_str, torch.zeros((self.buffer_size,*attr.shape[1:]), dtype=typ, device=self.device))
+
+
+    def get_size(self):
+        return self.num_seen_examples
+    
+    def __len__(self):
+        return self.num_seen_examples
+
+    def add_data(self, input_ids,  labels=None, logits=None, attention_mask=None, task=None, nsp_labels=None):
+
+        if not hasattr(self, 'input_ids'):
+            self.init_tensors(input_ids,labels,logits, attention_mask,task,nsp_labels)
+
+        for i in range(input_ids.shape[0]):
+            index = reservoir(self.num_seen_examples, self.buffer_size)
+            self.num_seen_examples += 1
+            if index >= 0:
+                self.input_ids[index] = input_ids[i].to(self.device)
+                if labels is not None:
+                    self.labels[index] = labels[i].to(self.device)
+                if logits is not None:
+                    self.logits[index] = logits[i].to(self.device)
+                if task is not None:
+                    self.task[index] = task[i].to(self.device)
+                if nsp_labels is not None:
+                    self.nsp_labels[index] = nsp_labels[i].to(self.device)
+                if attention_mask is not None:
+                    self.attention_mask[index] = attention_mask[i].to(self.device)
+
+    def get_data(self, size: int, transform: transforms=None) -> Tuple:
+        """
+        Random samples a batch of size items.
+        :param size: the number of requested items
+        :param transform: the transformation to be applied (data augmentation)
+        :return:
+        """
+        if size > min(self.num_seen_examples, self.input_ids.shape[0]):
+            size = min(self.num_seen_examples, self.input_ids.shape[0])
+
+        choice = np.random.choice(min(self.num_seen_examples, self.input_ids.shape[0]),
+                                  size=size, replace=False)
+        if transform is None: transform = lambda x: x
+        ret_tuple = (torch.stack([transform(ee.cpu())
+                            for ee in self.input_ids[choice]]).to(self.device),)
+        for attr_str in self.attributes[1:]:
+            if hasattr(self, attr_str):
+                attr = getattr(self, attr_str)
+                ret_tuple += (attr[choice],)
+
+        return ret_tuple
+    
+    def get_datadict(self, size: int, transform: transforms=None) -> Dict:
+        """
+        Random samples a batch of size items.
+        :param size: the number of requested items
+        :param transform: the transformation to be applied (data augmentation)
+        :return:
+        """
+        if size > min(self.num_seen_examples, self.input_ids.shape[0]):
+            size = min(self.num_seen_examples, self.input_ids.shape[0])
+
+        choice = np.random.choice(min(self.num_seen_examples, self.input_ids.shape[0]),
+                                  size=size, replace=False)
+        if transform is None: transform = lambda x: x
+        ret_dict = {'input_ids': torch.stack([transform(ee.cpu())
+                            for ee in self.input_ids[choice]]).to(self.device),}
+        for attr_str in self.attributes[1:]:
+            if hasattr(self, attr_str):
+                attr = getattr(self, attr_str)
+                ret_dict[attr_str] = attr[choice]
+
+        return ret_dict
+
+    def is_empty(self) -> bool:
+        """
+        Returns true if the buffer is empty, false otherwise.
+        """
+        if self.num_seen_examples == 0:
+            return True
+        else:
+            return False
+
+    def get_all_data(self, transform: transforms=None) -> Tuple:
+        """
+        Return all the items in the memory buffer.
+        :param transform: the transformation to be applied (data augmentation)
+        :return: a tuple with all the items in the memory buffer
+        """
+        if transform is None: transform = lambda x: x
+        ret_tuple = (torch.stack([transform(ee.cpu())
+                            for ee in self.input_ids]).to(self.device),)
+        for attr_str in self.attributes[1:]:
+            if hasattr(self, attr_str):
+                attr = getattr(self, attr_str)
+                ret_tuple += (attr,)
+        return ret_tuple
+
+    def empty(self) -> None:
+        """
+        Set all the tensors to None.
+        """
+        for attr_str in self.attributes:
+            if hasattr(self, attr_str):
+                delattr(self, attr_str)
+        self.num_seen_examples = 0

--- a/networks/classification.py
+++ b/networks/classification.py
@@ -1,8 +1,8 @@
 from networks.baselines import supsup
-from networks.baselines import ewc, hat
+from networks.baselines import ewc, hat, ldbr
+import torch
 
-
-def run_forward(input_ids,attention_mask,task,cls_labels,my_model,self_fisher,masks=None, mask_pre=None):
+def run_forward(input_ids,attention_mask,task,cls_labels,my_model,self_fisher,masks=None, mask_pre=None, nsp_labels=None):
 
         if 'supsup' in my_model.args.baseline:
             if 'mtl' in my_model.args.baseline: # these are only useful for supsup
@@ -25,17 +25,23 @@ def run_forward(input_ids,attention_mask,task,cls_labels,my_model,self_fisher,ma
         else:
 
             if my_model.args.is_reference:
-                outputs = my_model.teacher(input_ids=input_ids, labels=cls_labels,attention_mask=attention_mask,output_hidden_states=True,task=task)
+                outputs = my_model.teacher(input_ids=input_ids, labels=cls_labels, attention_mask=attention_mask, output_hidden_states=True, task=task, nsp_labels=nsp_labels)
             else:
-                outputs = my_model.model(input_ids=input_ids, labels=cls_labels,attention_mask=attention_mask,output_hidden_states=True,task=task)
+                outputs = my_model.model(input_ids=input_ids, labels=cls_labels, attention_mask=attention_mask, output_hidden_states=True, task=task, nsp_labels=nsp_labels)
 
             loss = outputs.loss
             logits = outputs.logits
+            hidden_states = outputs.hidden_states
 
         if 'ewc' in my_model.args.baseline and my_model.training and self_fisher is not None:  # only if we are training
 
             loss += ewc.loss_compute(my_model,self_fisher)
 
+        elif 'ldbr' in my_model.args.baseline and my_model.training and my_model.args.ft_task > 0:
+            
+            with torch.no_grad():
+                teacher_outputs = my_model.teacher(input_ids=input_ids, labels=cls_labels, attention_mask=attention_mask, output_hidden_states=True, task=task, nsp_labels=nsp_labels)
+            loss += ldbr.regularization(outputs, teacher_outputs)
 
         elif ('adapter_hat' in my_model.args.baseline or 'adapter_cat' in my_model.args.baseline
                 or 'adapter_bcl' in my_model.args.baseline
@@ -44,5 +50,5 @@ def run_forward(input_ids,attention_mask,task,cls_labels,my_model,self_fisher,ma
 
             loss += hat.loss_compute(masks,mask_pre,my_model.args)
 
-        return loss, logits
+        return loss, logits, hidden_states
 

--- a/networks/classification.py
+++ b/networks/classification.py
@@ -23,7 +23,6 @@ def run_forward(input_ids,attention_mask,task,cls_labels,my_model,self_fisher,ma
                     supsup.set_model_specific_task(my_model, task)  # in case nothing is used
 
         else:
-
             if my_model.args.is_reference:
                 outputs = my_model.teacher(input_ids=input_ids, labels=cls_labels, attention_mask=attention_mask, output_hidden_states=True, task=task, nsp_labels=nsp_labels)
             else:

--- a/networks/generation.py
+++ b/networks/generation.py
@@ -61,6 +61,7 @@ def run_forward(input_ids,attention_mask,task,labels,my_model,self_fisher,masks=
 
         loss = outputs.loss
         logits = outputs.logits
+        hidden_states = outputs.hidden_states
 
 
     if 'ewc' in my_model.args.baseline and my_model.training and self_fisher is not None:
@@ -74,4 +75,4 @@ def run_forward(input_ids,attention_mask,task,labels,my_model,self_fisher,masks=
 
         loss += hat.loss_compute(masks, mask_pre, my_model.args)
 
-    return loss, logits
+    return loss, logits, hidden_states

--- a/networks/generation.py
+++ b/networks/generation.py
@@ -34,7 +34,7 @@ def run_forward(input_ids,attention_mask,task,labels,my_model,self_fisher,masks=
 
 
 
-        return None,None
+        return None,None,None
 
     # TODO: bellow for training -------------------------------------
 
@@ -61,7 +61,7 @@ def run_forward(input_ids,attention_mask,task,labels,my_model,self_fisher,masks=
 
         loss = outputs.loss
         logits = outputs.logits
-        hidden_states = outputs.hidden_states
+        hidden_states = outputs.encoder_hidden_states    # TODO: to consistent with classification
 
 
     if 'ewc' in my_model.args.baseline and my_model.training and self_fisher is not None:

--- a/networks/prompt/tuning.py
+++ b/networks/prompt/tuning.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 from networks.bart import MyBartForConditionalGeneration,MyBartForSequenceClassification,MyBartForTokenClassification
 from networks.bart import shift_tokens_right
+from networks.roberta import MyRobertaForSequenceClassification, MyRobertaForTokenClassification
 
 class BARTPromptTuningMixinCommon:
 
@@ -186,8 +187,118 @@ class BARTPromptTuningMixinClassification(BARTPromptTuningMixinCommon):
             task=task
         )
 
+class RobertaPromptTuningMixinCommon:
+    def initialize_soft_prompt(self, n_tokens):
+        if 'one' in self.args.baseline:
+            self.prompt_embedding = nn.parameter.Parameter(
+                self.roberta.embeddings.word_embeddings.weight[:n_tokens].clone().detach())
+
+        elif 'l2p' in self.args.baseline:
+            init_prompt_value = torch.FloatTensor(self.args.M, self.args.Lp * self.config.hidden_size).uniform_(-0.5, 0.5)
+            self.prompt_pool = nn.Embedding(self.args.M, self.args.Lp * self.config.hidden_size)
+            self.prompt_pool.weight = nn.parameter.Parameter(init_prompt_value)
+
+        else:
+            raise NotImplementedError
+
+    def set_soft_prompt_embeds(self, soft_prompt_embeds):
+        self.prompt_embedding = nn.parameter.Parameter(soft_prompt_embeds.clone().detach())
+
+    def get_soft_params(self):
+        return self.prompt_embedding
+
+    def prepare_inputs_for_generation(self, input_ids, past=None, *args, **kwargs):
+        input_ids = input_ids.to(self.device)
+        # Drop 'past' to make things easier for us later
+        return super().prepare_inputs_for_generation(input_ids, None, *args, **kwargs)
+
+    def _cat_prompt_embedding_to_input(self, input_ids):
+        inputs_embeds = self.roberta.embeddings.word_embeddings(input_ids)
+
+        if len(list(inputs_embeds.shape)) == 2:
+            ie = inputs_embeds.unsqueeze(0)
+        else:
+            ie = inputs_embeds
+
+        # prompt_embedding = self.model.drop(self.prompt_embedding)
+        prompt_embedding = self.prompt_embedding
+
+        inputs_embeds = torch.cat([prompt_embedding.repeat(ie.size(0), 1, 1),
+                                   ie],
+                                   dim=1)
+
+        return inputs_embeds
+
+    def _extend_labels(self, labels):
+        n_tokens = self.prompt_embedding.shape[-2]
+
+        if len(list(labels.shape)) == 1:
+            lb = labels.unsqueeze(0)
+        else:
+            lb = labels
+
+        # Add '-100's (prevent loss calculation where the learned embed would be)
+        n_batches = lb.shape[0]
+        return torch.cat([torch.full((n_batches,n_tokens), -100).to(self.device), lb], dim=1)
+
+    def _extend_attention_mask(self, attention_mask):
+        n_tokens = self.prompt_embedding.shape[-2]
+
+        if len(list(attention_mask.shape)) == 1:
+            am = attention_mask.unsqueeze(0)
+        else:
+            am = attention_mask
+
+        n_batches = am.shape[0]
+        return torch.cat([torch.full((n_batches,n_tokens), 1).to(self.device), am], dim=1)
+
+    def get_prompt_extended_input_exclude_label(self,input_ids,attention_mask):
+        inputs_embeds = self._cat_prompt_embedding_to_input(input_ids)
+        attention_mask = self._extend_attention_mask(attention_mask)
+
+        return inputs_embeds,attention_mask
+
+class RobertaPromptTuningMixinClassification(RobertaPromptTuningMixinCommon):
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        token_type_ids=None,
+        position_ids=None,
+        head_mask=None,
+        inputs_embeds=None,
+        labels=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        task=None,
+        my_loss=None,
+        nsp_labels=None,
+    ):
 
 
+        if input_ids is not None:
+            inputs_embeds = self._cat_prompt_embedding_to_input(input_ids)
+
+        if attention_mask is not None:
+            attention_mask = self._extend_attention_mask(attention_mask)
+
+        # Drop most of the args for now
+        return super().forward(
+            input_ids=None, # TODO: we don't want to use input_ids , to debug.
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            task=task,
+            my_loss=my_loss,
+            nsp_labels=nsp_labels,
+        )
 
 
 class MyBartForConditionalGenerationSoftPromptTunning(BARTPromptTuningMixinGeneration, MyBartForConditionalGeneration):
@@ -207,5 +318,26 @@ class MyBartForTokenClassificationSoftPromptTunning(BARTPromptTuningMixinClassif
     def __init__(self, config, **kwargs):
         BARTPromptTuningMixinClassification.__init__(self)
         MyBartForTokenClassification.__init__(self, config, **kwargs)
+        self.config = config
+        self.args = kwargs['args']
+
+class MyBartForSequenceClassificationSoftPromptTunning(BARTPromptTuningMixinClassification, MyBartForSequenceClassification):
+    def __init__(self, config, **kwargs):
+        BARTPromptTuningMixinClassification.__init__(self)
+        MyBartForSequenceClassification.__init__(self, config, **kwargs)
+        self.config = config
+        self.args = kwargs['args']
+
+class MyRobertaForTokenClassificationSoftPromptTunning(RobertaPromptTuningMixinClassification, MyRobertaForTokenClassification):
+    def __init__(self, config, **kwargs):
+        RobertaPromptTuningMixinClassification.__init__(self)
+        MyRobertaForTokenClassification.__init__(self, config, **kwargs)
+        self.config = config
+        self.args = kwargs['args']
+
+class MyRobertaForSequenceClassificationSoftPromptTunning(RobertaPromptTuningMixinClassification, MyRobertaForSequenceClassification):
+    def __init__(self, config, **kwargs):
+        RobertaPromptTuningMixinClassification.__init__(self)
+        MyRobertaForSequenceClassification.__init__(self, config, **kwargs)
         self.config = config
         self.args = kwargs['args']

--- a/networks/roberta.py
+++ b/networks/roberta.py
@@ -1004,7 +1004,8 @@ class MyRobertaForSequenceClassification(ModelWithHeadsAdaptersMixin, RobertaPre
         output_hidden_states=None,
         return_dict=None,
         task=None,
-        my_loss = None
+        my_loss = None,
+        nsp_labels=None,
     ):
 
         r"""
@@ -1160,7 +1161,7 @@ class MyRobertaForTokenClassification(ModelWithHeadsAdaptersMixin, RobertaPreTra
         inputs_embeds=None,
         labels=None,
         output_attentions=None,
-        output_hidden_states=None,
+        output_hidden_states=True,
         return_dict=None,
         my_loss=None,
         task=None

--- a/networks/roberta.py
+++ b/networks/roberta.py
@@ -1049,7 +1049,8 @@ class MyRobertaForSequenceClassification(ModelWithHeadsAdaptersMixin, RobertaPre
                 loss += cur_loss
                 logits.append(logit)
 
-            if 'mtl' not in self.args.baseline and 'comb' not in self.args.baseline:
+            if 'mtl' not in self.args.baseline and 'comb' not in self.args.baseline and 'agem' not in self.args.baseline and 'derpp' not in self.args.baseline:
+                # TODO: all replay methods should not calculate this.
                 logits = torch.cat(logits)
 
             loss = loss / len(task)
@@ -1057,9 +1058,10 @@ class MyRobertaForSequenceClassification(ModelWithHeadsAdaptersMixin, RobertaPre
         else:
             logits = []
             for t in range(self.args.ntasks):
+                # [B, hidden] -> [B, labels]
                 logit = self.classifiers[t](sequence_output)
                 logits.append(logit)
-            logits = torch.cat(logits,dim=1)
+            logits = torch.cat(logits,dim=-1)
 
 
         #
@@ -1133,13 +1135,8 @@ class MyRobertaForTokenClassification(ModelWithHeadsAdaptersMixin, RobertaPreTra
         self.classifiers = nn.ModuleList()
         for task, n in taskcla:
             config.num_labels = n
-
             classifier = nn.Linear(config.hidden_size, config.num_labels)
-            self.model._init_weights(classifier.dense)
-            self.model._init_weights(classifier.out_proj)
-
             self.classifiers.append(classifier)
-
 
         # Initialize weights and apply final processing
         self.post_init()
@@ -1164,7 +1161,8 @@ class MyRobertaForTokenClassification(ModelWithHeadsAdaptersMixin, RobertaPreTra
         output_hidden_states=True,
         return_dict=None,
         my_loss=None,
-        task=None
+        task=None,
+        nsp_labels=None
     ):
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
@@ -1184,7 +1182,8 @@ class MyRobertaForTokenClassification(ModelWithHeadsAdaptersMixin, RobertaPreTra
             return_dict=return_dict,
         )
 
-        sequence_output = outputs[0]
+        # adapt prompt to token classification !!
+        sequence_output = outputs[0][...,-self.args.max_length:,:]
 
         sequence_output = self.dropout(sequence_output)
 
@@ -1203,7 +1202,8 @@ class MyRobertaForTokenClassification(ModelWithHeadsAdaptersMixin, RobertaPreTra
                 loss += cur_loss
                 logits.append(logit)
 
-            if 'mtl' not in self.args.baseline and 'comb' not in self.args.baseline:
+            if 'mtl' not in self.args.baseline and 'comb' not in self.args.baseline and 'derpp' not in self.args.baseline and 'agem' not in self.args.baseline:
+                # TODO: all replay methods should not calculate this.
                 logits = torch.cat(logits)
 
             loss = loss / len(task)
@@ -1213,7 +1213,7 @@ class MyRobertaForTokenClassification(ModelWithHeadsAdaptersMixin, RobertaPreTra
             for t in range(self.args.ntasks):
                 logit = self.classifiers[t](sequence_output)
                 logits.append(logit)
-            logits = torch.cat(logits,dim=1)
+            logits = torch.cat(logits,dim=-1)
 
 
         # loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -919,7 +919,7 @@ def _lookfor_model_others(taskcla,args, config):
 
     return model
 
-def lookfor_model_finetune(taskcla,args, config):
+def lookfor_model_finetune(taskcla, args, config):
 
     if args.model_name_or_path:  # only do electra
         if 'adapter' in args.baseline:


### PR DESCRIPTION
1. Add the generation and token classification models for Der++, A-Gem, LDBR, DyTox, DualPrompt baselines.
2. Add Roberta for prompt-based methods (previously only BART)
3. Add `buffer.py` in `./networks` for replay-based methods.
4. Note that LDBR and DyTox are not suitable for generation and NER. LDBR adds a 'sep' token into the input to do an NSP task, and DyTox uses a task attention block that only attends to a task token (outputs a sentence-level representation). Here they are not included in this update.